### PR TITLE
Feature/add extra parameters in some methods

### DIFF
--- a/hyperon_das_atomdb/adapters/hash_table.py
+++ b/hyperon_das_atomdb/adapters/hash_table.py
@@ -434,6 +434,14 @@ class InMemoryDB(IAtomDB):
 
         return link_db[key]
 
+    def targets_is_toplevel(self, target_handles: List[str]) -> bool:
+        for link_handle, targets in self.db.outgoing_set.items():
+            if set(targets) == set(target_handles):
+                arity = len(target_handles)
+                links = self.db.link.get_arity(arity)
+                return links[link_handle]['is_toplevel']
+        return False
+
     def _create_node_handle(self, node_type: str, node_name: str) -> str:
         return ExpressionHasher.terminal_hash(node_type, node_name)
 

--- a/hyperon_das_atomdb/adapters/hash_table.py
+++ b/hyperon_das_atomdb/adapters/hash_table.py
@@ -651,3 +651,29 @@ class InMemoryDB(IAtomDB):
             if links[link_handle]['is_toplevel'] == False:
                 matches_copy.remove(match)
         return matches_copy
+
+
+if __name__ == '__main__':
+    api = InMemoryDB()
+    r = api.add_link(
+        {
+            'type': 'Evaluation',
+            'targets': [
+                {'type': 'Predicate', 'name': 'Predicate:has_name'},
+                {
+                    'type': 'Evaluation',
+                    'targets': [
+                        {
+                            'type': 'Reactome',
+                            'name': 'Reactome:R-HSA-164843',
+                        },
+                        {
+                            'type': 'Concept',
+                            'name': 'Concept:2-LTR circle formation',
+                        },
+                    ],
+                },
+            ],
+        }
+    )
+    print(r)

--- a/hyperon_das_atomdb/adapters/redis_mongo_db.py
+++ b/hyperon_das_atomdb/adapters/redis_mongo_db.py
@@ -510,3 +510,20 @@ class RedisMongoDB(IAtomDB):
             self.mongo_db[collection].drop()
 
         self.redis.flushall()
+
+    def targets_is_toplevel(self, target_handles: List[str]) -> bool:
+        answers = self.redis.keys(f'{KeyPrefix.OUTGOING_SET.value}:*')
+
+        if answers:
+            outgoing_sets_keys = [answer.decode() for answer in answers]
+
+            for key in outgoing_sets_keys:
+                members = self.redis.smembers(key)
+                if set([m.decode() for m in members]) == set(target_handles):
+                    handle = key.replace('outgoing_set:', '')
+                    document = self._retrieve_mongo_document(
+                        handle, len(target_handles)
+                    )
+                    return document['is_toplevel']
+
+        return False

--- a/hyperon_das_atomdb/adapters/redis_mongo_db.py
+++ b/hyperon_das_atomdb/adapters/redis_mongo_db.py
@@ -543,6 +543,8 @@ class RedisMongoDB(IAtomDB):
         self.redis.flushall()
 
     def _remove_links_not_toplevel(self, matches: list) -> list:
+        if isinstance(matches[0], list):
+            matches = matches[0]
         matches_copy = matches[:]
         for match in matches:
             link_handle = match[0]
@@ -550,11 +552,3 @@ class RedisMongoDB(IAtomDB):
             if link['is_toplevel'] == False:
                 matches_copy.remove(match)
         return matches_copy
-
-
-if __name__ == '__main__':
-    api = RedisMongoDB()
-    ret = api.get_matched_links(
-        'Evaluation', ['*', '*'], {'only_toplevel': True}
-    )
-    print(ret)

--- a/hyperon_das_atomdb/i_database.py
+++ b/hyperon_das_atomdb/i_database.py
@@ -69,6 +69,9 @@ class IAtomDB(ABC):
     def add_link(self, link_type: str, targets: List[str]) -> None:
         ...  # pragma no cover
 
+    def targets_is_toplevel(self, target_handles: List[str]) -> bool:
+        ...  # pragma no cover
+
     def get_atom_as_dict(self, handle: str, arity: int):
         ...  # pragma no cover
 

--- a/hyperon_das_atomdb/i_database.py
+++ b/hyperon_das_atomdb/i_database.py
@@ -69,9 +69,6 @@ class IAtomDB(ABC):
     def add_link(self, link_type: str, targets: List[str]) -> None:
         ...  # pragma no cover
 
-    def targets_is_toplevel(self, target_handles: List[str]) -> bool:
-        ...  # pragma no cover
-
     def get_atom_as_dict(self, handle: str, arity: int):
         ...  # pragma no cover
 

--- a/tests/adapters/test_hash_table.py
+++ b/tests/adapters/test_hash_table.py
@@ -1,11 +1,16 @@
 import pytest
 
 from hyperon_das_atomdb.adapters.hash_table import InMemoryDB
-from hyperon_das_atomdb.exceptions import AddLinkException, AddNodeException, LinkDoesNotExistException, NodeDoesNotExistException
+from hyperon_das_atomdb.exceptions import (
+    AddLinkException,
+    AddNodeException,
+    LinkDoesNotExistException,
+    NodeDoesNotExistException,
+)
 from hyperon_das_atomdb.utils.expression_hasher import ExpressionHasher
 
+
 class TestInMemoryDB:
-    
     @pytest.fixture()
     def all_nodes(self):
         return [
@@ -24,7 +29,7 @@ class TestInMemoryDB:
             {'type': 'Concept', 'name': 'dinosaur'},
             {'type': 'Concept', 'name': 'plant'},
         ]
-    
+
     @pytest.fixture()
     def all_links(self):
         return [
@@ -220,50 +225,63 @@ class TestInMemoryDB:
         for link in all_links:
             db.add_link(link)
         return db
-        
-    
+
     def test_get_node_handle(self, database: InMemoryDB):
-        actual = database.get_node_handle(node_type="Concept", node_name="human")
+        actual = database.get_node_handle(
+            node_type="Concept", node_name="human"
+        )
         expected = ExpressionHasher.terminal_hash('Concept', 'human')
         assert expected == actual
-    
+
     def test_get_node_handle_not_exist(self, database: InMemoryDB):
         with pytest.raises(NodeDoesNotExistException) as exc_info:
-            database.get_node_handle(node_type="Concept-Fake", node_name="fake")
+            database.get_node_handle(
+                node_type="Concept-Fake", node_name="fake"
+            )
         assert exc_info.type is NodeDoesNotExistException
         assert exc_info.value.args[0] == "This node does not exist"
-        
+
     def test_get_link_handle(self, database: InMemoryDB):
         human = database.get_node_handle('Concept', 'human')
         chimp = database.get_node_handle('Concept', 'chimp')
-        actual = database.get_link_handle(link_type='Similarity', target_handles=[human, chimp])
+        actual = database.get_link_handle(
+            link_type='Similarity', target_handles=[human, chimp]
+        )
         expected = 'b5459e299a5c5e8662c427f7e01b3bf1'
         assert expected == actual
-        
+
     def test_get_link_handle_not_exist(self, database: InMemoryDB):
         with pytest.raises(LinkDoesNotExistException) as exc_info:
-            database.get_link_handle(link_type='Singularity', target_handles=['Fake-1', 'Fake-2'])
+            database.get_link_handle(
+                link_type='Singularity', target_handles=['Fake-1', 'Fake-2']
+            )
         assert exc_info.type is LinkDoesNotExistException
         assert exc_info.value.args[0] == "This link does not exist"
-        
+
     def test_node_exists_true(self, database: InMemoryDB):
         ret = database.node_exists(node_type="Concept", node_name="human")
-        assert ret is True  
-    
+        assert ret is True
+
     def test_node_exists_false(self, database: InMemoryDB):
-        ret = database.node_exists(node_type="Concept-Fake", node_name="human-fake")
-        assert ret is False  
-    
+        ret = database.node_exists(
+            node_type="Concept-Fake", node_name="human-fake"
+        )
+        assert ret is False
+
     def test_link_exists_true(self, database: InMemoryDB):
         human = database.get_node_handle('Concept', 'human')
         monkey = database.get_node_handle('Concept', 'monkey')
-        ret = database.link_exists(link_type="Similarity", target_handles=[human, monkey])
-        assert ret is True  
-    
+        ret = database.link_exists(
+            link_type="Similarity", target_handles=[human, monkey]
+        )
+        assert ret is True
+
     def test_link_exists_false(self, database: InMemoryDB):
-        ret = database.link_exists(link_type="Concept-Fake", target_handles=['Fake1, Fake2'])
+        ret = database.link_exists(
+            link_type="Concept-Fake", target_handles=['Fake1, Fake2']
+        )
         assert ret is False
-        
+
     def test_get_link_targets(self, database: InMemoryDB):
         human = database.get_node_handle('Concept', 'human')
         mammal = database.get_node_handle('Concept', 'mammal')
@@ -276,18 +294,18 @@ class TestInMemoryDB:
             database.get_link_targets(f'link_handle_Fake')
         assert exc_info.type is LinkDoesNotExistException
         assert exc_info.value.args[0] == "This link does not exist"
-    
+
     def test_is_ordered_true(self, database: InMemoryDB):
         human = database.get_node_handle('Concept', 'human')
         mammal = database.get_node_handle('Concept', 'mammal')
         handle = database.get_link_handle('Inheritance', [human, mammal])
         ret = database.is_ordered(handle)
         assert ret is True
-    
+
     def test_is_ordered_false(self, database: InMemoryDB):
         ret = database.is_ordered('handle_123')
         assert ret is False
-        
+
     def test_get_matched_links_without_wildcard(self, database):
         link_type = 'Similarity'
         human = ExpressionHasher.terminal_hash('Concept', 'human')
@@ -302,7 +320,7 @@ class TestInMemoryDB:
         human = ExpressionHasher.terminal_hash('Concept', 'human')
         chimp = ExpressionHasher.terminal_hash('Concept', 'chimp')
         expected = [
-                (
+            (
                 "b5459e299a5c5e8662c427f7e01b3bf1",
                 (
                     "af12f10f9ae2002a1607ba0b47ba8407",
@@ -322,21 +340,21 @@ class TestInMemoryDB:
                 'b5459e299a5c5e8662c427f7e01b3bf1',
                 (
                     'af12f10f9ae2002a1607ba0b47ba8407',
-                    '5b34c54bee150c04f9fa584b899dc030'
-                )
+                    '5b34c54bee150c04f9fa584b899dc030',
+                ),
             ),
             (
                 '31535ddf214f5b239d3b517823cb8144',
                 (
                     '1cdffc6b0b89ff41d68bec237481d1e1',
-                    '5b34c54bee150c04f9fa584b899dc030'
-                )
-            )
+                    '5b34c54bee150c04f9fa584b899dc030',
+                ),
+            ),
         ]
-        
+
         actual = database.get_matched_links(link_type, ['*', chimp])
         assert expected == actual
-    
+
     def test_get_matched_links_link_does_not_exist(self, database: InMemoryDB):
         link_type = 'Similarity-Fake'
         chimp = ExpressionHasher.terminal_hash('Concept', 'chimp')
@@ -344,74 +362,91 @@ class TestInMemoryDB:
             database.get_matched_links(link_type, [chimp, chimp])
         assert exc_info.type is LinkDoesNotExistException
         assert exc_info.value.args[0] == "This link does not exist"
-    
+
     def test_get_matched_links_only_toplevel(self, database: InMemoryDB):
-        database.add_link({
-            'type': 'Evaluation',
-            'targets': [
-                {'type': 'Predicate', 'name': 'Predicate:has_name'},
-                {
-                    'type': 'Evaluation',
-                    'targets': [
-                        {'type': 'Predicate', 'name': 'Predicate:has_name'},
-                        {
-                            'targets': [
-                                {
-                                    'type': 'Reactome',
-                                    'name': 'Reactome:R-HSA-164843',
-                                },
-                                {
-                                    'type': 'Concept',
-                                    'name': 'Concept:2-LTR circle formation',
-                                },
-                            ],
-                            'type': 'Set',
-                        },
-                    ],
-                },
-            ],
-        })
+        database.add_link(
+            {
+                'type': 'Evaluation',
+                'targets': [
+                    {'type': 'Predicate', 'name': 'Predicate:has_name'},
+                    {
+                        'type': 'Evaluation',
+                        'targets': [
+                            {
+                                'type': 'Predicate',
+                                'name': 'Predicate:has_name',
+                            },
+                            {
+                                'targets': [
+                                    {
+                                        'type': 'Reactome',
+                                        'name': 'Reactome:R-HSA-164843',
+                                    },
+                                    {
+                                        'type': 'Concept',
+                                        'name': 'Concept:2-LTR circle formation',
+                                    },
+                                ],
+                                'type': 'Set',
+                            },
+                        ],
+                    },
+                ],
+            }
+        )
         expected = [
             (
                 '661fb5a7c90faabfeada7e1f63805fc0',
-                ('a912032ece1826e55fa583dcaacdc4a9', '260e118be658feeeb612dcd56d270d77')
+                (
+                    'a912032ece1826e55fa583dcaacdc4a9',
+                    '260e118be658feeeb612dcd56d270d77',
+                ),
             )
         ]
-        actual = database.get_matched_links('Evaluation', ['*', '*'], {'only_toplevel': True})
+        actual = database.get_matched_links(
+            'Evaluation', ['*', '*'], {'only_toplevel': True}
+        )
 
         assert expected == actual
         assert len(actual) == 1
-    
+
     def test_get_matched_links_wrong_parameter(self, database: InMemoryDB):
-        database.add_link({
-            'type': 'Evaluation',
-            'targets': [
-                {'type': 'Predicate', 'name': 'Predicate:has_name'},
-                {
-                    'type': 'Evaluation',
-                    'targets': [
-                        {'type': 'Predicate', 'name': 'Predicate:has_name'},
-                        {
-                            'targets': [
-                                {
-                                    'type': 'Reactome',
-                                    'name': 'Reactome:R-HSA-164843',
-                                },
-                                {
-                                    'type': 'Concept',
-                                    'name': 'Concept:2-LTR circle formation',
-                                },
-                            ],
-                            'type': 'Set',
-                        },
-                    ],
-                },
-            ],
-        })
-        actual = database.get_matched_links('Evaluation', ['*', '*'], {'toplevel': True})
+        database.add_link(
+            {
+                'type': 'Evaluation',
+                'targets': [
+                    {'type': 'Predicate', 'name': 'Predicate:has_name'},
+                    {
+                        'type': 'Evaluation',
+                        'targets': [
+                            {
+                                'type': 'Predicate',
+                                'name': 'Predicate:has_name',
+                            },
+                            {
+                                'targets': [
+                                    {
+                                        'type': 'Reactome',
+                                        'name': 'Reactome:R-HSA-164843',
+                                    },
+                                    {
+                                        'type': 'Concept',
+                                        'name': 'Concept:2-LTR circle formation',
+                                    },
+                                ],
+                                'type': 'Set',
+                            },
+                        ],
+                    },
+                ],
+            }
+        )
+        actual = database.get_matched_links(
+            'Evaluation', ['*', '*'], {'toplevel': True}
+        )
 
         assert len(actual) == 2
-    
+
     def test_get_all_nodes(self, database):
         ret = database.get_all_nodes('Concept')
         assert len(ret) == 14
@@ -419,12 +454,20 @@ class TestInMemoryDB:
         assert len(ret) == 14
         ret = database.get_all_nodes('ConceptFake')
         assert len(ret) == 0
-    
+
     def test_get_matched_type_template(self, database: InMemoryDB):
-        v1 = database.get_matched_type_template(['Inheritance', 'Concept', 'Concept'])
-        v2 = database.get_matched_type_template(['Similarity', 'Concept', 'Concept'])
-        v3 = database.get_matched_type_template(['Inheritance', 'Concept', 'blah'])
-        v4 = database.get_matched_type_template(['Similarity', 'blah', 'Concept'])
+        v1 = database.get_matched_type_template(
+            ['Inheritance', 'Concept', 'Concept']
+        )
+        v2 = database.get_matched_type_template(
+            ['Similarity', 'Concept', 'Concept']
+        )
+        v3 = database.get_matched_type_template(
+            ['Inheritance', 'Concept', 'blah']
+        )
+        v4 = database.get_matched_type_template(
+            ['Similarity', 'blah', 'Concept']
+        )
         v5 = database.get_matched_links('Inheritance', ['*', '*'])
         v6 = database.get_matched_links('Similarity', ['*', '*'])
         assert len(v1) == 12
@@ -434,65 +477,77 @@ class TestInMemoryDB:
         assert v1 == v5
         assert v2 == v6
 
-    def test_get_matched_type_template_only_toplevel(self, database: InMemoryDB):
-        database.add_link({
-            'type': 'Evaluation',
-            'targets': [
-                {'type': 'Predicate', 'name': 'Predicate:has_name'},
-                {
-                    'type': 'Evaluation',
-                    'targets': [
-                        {
-                            'type': 'Reactome',
-                            'name': 'Reactome:R-HSA-164843',
-                        },
-                        {
-                            'type': 'Concept',
-                            'name': 'Concept:2-LTR circle formation',
-                        },
-                    ],
-                },
-            ],
-        })
-        
-        ret = database.get_matched_type_template(['Evaluation', 'Reactome', 'Concept'], {'only_toplevel': True})
+    def test_get_matched_type_template_only_toplevel(
+        self, database: InMemoryDB
+    ):
+        database.add_link(
+            {
+                'type': 'Evaluation',
+                'targets': [
+                    {'type': 'Predicate', 'name': 'Predicate:has_name'},
+                    {
+                        'type': 'Evaluation',
+                        'targets': [
+                            {
+                                'type': 'Reactome',
+                                'name': 'Reactome:R-HSA-164843',
+                            },
+                            {
+                                'type': 'Concept',
+                                'name': 'Concept:2-LTR circle formation',
+                            },
+                        ],
+                    },
+                ],
+            }
+        )
+
+        ret = database.get_matched_type_template(
+            ['Evaluation', 'Reactome', 'Concept'], {'only_toplevel': True}
+        )
 
         assert len(ret) == 0
-        
-        ret = database.get_matched_type_template(['Evaluation', 'Reactome', 'Concept'], {'only_toplevel': False})
+
+        ret = database.get_matched_type_template(
+            ['Evaluation', 'Reactome', 'Concept'], {'only_toplevel': False}
+        )
 
         assert len(ret) == 1
-    
+
     def test_get_matched_type(self, database: InMemoryDB):
         inheritance = database.get_matched_type('Inheritance')
         similarity = database.get_matched_type('Similarity')
         assert len(inheritance) == 12
         assert len(similarity) == 14
-    
+
     def test_get_matched_type_only_toplevel(self, database: InMemoryDB):
-        database.add_link({
-            'type': 'EvaluationLink',
-            'targets': [
-                {'type': 'Predicate', 'name': 'Predicate:has_name'},
-                {
-                    'type': 'EvaluationLink',
-                    'targets': [
-                        {
-                            'type': 'Reactome',
-                            'name': 'Reactome:R-HSA-164843',
-                        },
-                        {
-                            'type': 'Concept',
-                            'name': 'Concept:2-LTR circle formation',
-                        },
-                    ],
-                },
-            ],
-        })
+        database.add_link(
+            {
+                'type': 'EvaluationLink',
+                'targets': [
+                    {'type': 'Predicate', 'name': 'Predicate:has_name'},
+                    {
+                        'type': 'EvaluationLink',
+                        'targets': [
+                            {
+                                'type': 'Reactome',
+                                'name': 'Reactome:R-HSA-164843',
+                            },
+                            {
+                                'type': 'Concept',
+                                'name': 'Concept:2-LTR circle formation',
+                            },
+                        ],
+                    },
+                ],
+            }
+        )
         ret = database.get_matched_type('EvaluationLink')
         assert len(ret) == 2
 
-        ret = database.get_matched_type('EvaluationLink', {'only_toplevel': True})
+        ret = database.get_matched_type(
+            'EvaluationLink', {'only_toplevel': True}
+        )
         assert len(ret) == 1
 
     def test_get_node_name(self, database):
@@ -500,19 +555,19 @@ class TestInMemoryDB:
         db_name = database.get_node_name(handle)
 
         assert db_name == 'monkey'
-    
+
     def test_get_node_name_error(self, database):
         with pytest.raises(NodeDoesNotExistException) as exc_info:
             database.get_node_name('handle-test')
         assert exc_info.type is NodeDoesNotExistException
         assert exc_info.value.args[0] == "This node does not exist"
-        
+
     def test_get_node_type(self, database):
         handle = database.get_node_handle('Concept', 'monkey')
         db_type = database.get_node_type(handle)
 
         assert db_type == 'Concept'
-    
+
     def test_get_node_type_error(self, database):
         with pytest.raises(NodeDoesNotExistException) as exc_info:
             database.get_node_type('handle-test')
@@ -532,19 +587,25 @@ class TestInMemoryDB:
         assert expected == actual
         assert sorted(database.get_matched_node_name('blah', 'Concept')) == []
         assert sorted(database.get_matched_node_name('Concept', 'blah')) == []
-    
+
     def test_add_node_without_type_parameter(self, database: InMemoryDB):
         with pytest.raises(AddNodeException) as exc_info:
             database.add_node({'color': 'red', 'name': 'car'})
         assert exc_info.type is AddNodeException
-        assert exc_info.value.args[0] == 'The "name" and "type" fields must be sent'
-    
+        assert (
+            exc_info.value.args[0]
+            == 'The "name" and "type" fields must be sent'
+        )
+
     def test_add_node_without_name_parameter(self, database: InMemoryDB):
         with pytest.raises(AddNodeException) as exc_info:
             database.add_node({'type': 'Concept', 'color': 'red'})
         assert exc_info.type is AddNodeException
-        assert exc_info.value.args[0] == 'The "name" and "type" fields must be sent'
-    
+        assert (
+            exc_info.value.args[0]
+            == 'The "name" and "type" fields must be sent'
+        )
+
     def test_add_node(self, database: InMemoryDB):
         assert len(database.get_all_nodes('Concept')) == 14
         database.add_node({'type': 'Concept', 'name': 'car'})
@@ -558,60 +619,59 @@ class TestInMemoryDB:
             database.add_link(
                 {
                     'targets': [
-                        {
-                            'type': 'Concept',
-                            'name': 'human'
-                        },
-                        {
-                            'type': 'Concept',
-                            'name': 'monkey'
-                        }
+                        {'type': 'Concept', 'name': 'human'},
+                        {'type': 'Concept', 'name': 'monkey'},
                     ],
-                    'quantity': 2
+                    'quantity': 2,
                 }
             )
         assert exc_info.type is AddLinkException
-        assert exc_info.value.args[0] == 'The "type" and "targets" fields must be sent'
-    
+        assert (
+            exc_info.value.args[0]
+            == 'The "type" and "targets" fields must be sent'
+        )
+
     def test_add_link_without_targets_parameter(self, database: InMemoryDB):
         with pytest.raises(AddLinkException) as exc_info:
-            database.add_link(
-                {
-                    'source': 'fake',
-                    'type': 'Similarity'
-                }
-            )
+            database.add_link({'source': 'fake', 'type': 'Similarity'})
         assert exc_info.type is AddLinkException
-        assert exc_info.value.args[0] == 'The "type" and "targets" fields must be sent'
-    
+        assert (
+            exc_info.value.args[0]
+            == 'The "type" and "targets" fields must be sent'
+        )
+
     def test_add_nested_links(self, database: InMemoryDB):
         assert len(database.get_matched_type('Evaluation')) == 0
-        
-        database.add_link({
-            'type': 'Evaluation',
-            'targets': [
-                {'type': 'Predicate', 'name': 'Predicate:has_name'},
-                {
-                    'type': 'Evaluation',
-                    'targets': [
-                        {'type': 'Predicate', 'name': 'Predicate:has_name'},
-                        {
-                            'targets': [
-                                {
-                                    'type': 'Reactome',
-                                    'name': 'Reactome:R-HSA-164843',
-                                },
-                                {
-                                    'type': 'Concept',
-                                    'name': 'Concept:2-LTR circle formation',
-                                },
-                            ],
-                            'type': 'Set',
-                        },
-                    ],
-                },
-            ],
-        })
-        
-        assert len(database.get_matched_type('Evaluation')) == 2  
-        
+
+        database.add_link(
+            {
+                'type': 'Evaluation',
+                'targets': [
+                    {'type': 'Predicate', 'name': 'Predicate:has_name'},
+                    {
+                        'type': 'Evaluation',
+                        'targets': [
+                            {
+                                'type': 'Predicate',
+                                'name': 'Predicate:has_name',
+                            },
+                            {
+                                'targets': [
+                                    {
+                                        'type': 'Reactome',
+                                        'name': 'Reactome:R-HSA-164843',
+                                    },
+                                    {
+                                        'type': 'Concept',
+                                        'name': 'Concept:2-LTR circle formation',
+                                    },
+                                ],
+                                'type': 'Set',
+                            },
+                        ],
+                    },
+                ],
+            }
+        )
+
+        assert len(database.get_matched_type('Evaluation')) == 2

--- a/tests/adapters/test_hash_table.py
+++ b/tests/adapters/test_hash_table.py
@@ -345,6 +345,73 @@ class TestInMemoryDB:
         assert exc_info.type is LinkDoesNotExistException
         assert exc_info.value.args[0] == "This link does not exist"
     
+    def test_get_matched_links_only_toplevel(self, database: InMemoryDB):
+        database.add_link({
+            'type': 'Evaluation',
+            'targets': [
+                {'type': 'Predicate', 'name': 'Predicate:has_name'},
+                {
+                    'type': 'Evaluation',
+                    'targets': [
+                        {'type': 'Predicate', 'name': 'Predicate:has_name'},
+                        {
+                            'targets': [
+                                {
+                                    'type': 'Reactome',
+                                    'name': 'Reactome:R-HSA-164843',
+                                },
+                                {
+                                    'type': 'Concept',
+                                    'name': 'Concept:2-LTR circle formation',
+                                },
+                            ],
+                            'type': 'Set',
+                        },
+                    ],
+                },
+            ],
+        })
+        expected = [
+            (
+                '661fb5a7c90faabfeada7e1f63805fc0',
+                ('a912032ece1826e55fa583dcaacdc4a9', '260e118be658feeeb612dcd56d270d77')
+            )
+        ]
+        actual = database.get_matched_links('Evaluation', ['*', '*'], {'only_toplevel': True})
+
+        assert expected == actual
+        assert len(actual) == 1
+    
+    def test_get_matched_links_wrong_parameter(self, database: InMemoryDB):
+        database.add_link({
+            'type': 'Evaluation',
+            'targets': [
+                {'type': 'Predicate', 'name': 'Predicate:has_name'},
+                {
+                    'type': 'Evaluation',
+                    'targets': [
+                        {'type': 'Predicate', 'name': 'Predicate:has_name'},
+                        {
+                            'targets': [
+                                {
+                                    'type': 'Reactome',
+                                    'name': 'Reactome:R-HSA-164843',
+                                },
+                                {
+                                    'type': 'Concept',
+                                    'name': 'Concept:2-LTR circle formation',
+                                },
+                            ],
+                            'type': 'Set',
+                        },
+                    ],
+                },
+            ],
+        })
+        actual = database.get_matched_links('Evaluation', ['*', '*'], {'toplevel': True})
+
+        assert len(actual) == 2
+    
     def test_get_all_nodes(self, database):
         ret = database.get_all_nodes('Concept')
         assert len(ret) == 14
@@ -366,12 +433,67 @@ class TestInMemoryDB:
         assert len(v4) == 0
         assert v1 == v5
         assert v2 == v6
+
+    def test_get_matched_type_template_only_toplevel(self, database: InMemoryDB):
+        database.add_link({
+            'type': 'Evaluation',
+            'targets': [
+                {'type': 'Predicate', 'name': 'Predicate:has_name'},
+                {
+                    'type': 'Evaluation',
+                    'targets': [
+                        {
+                            'type': 'Reactome',
+                            'name': 'Reactome:R-HSA-164843',
+                        },
+                        {
+                            'type': 'Concept',
+                            'name': 'Concept:2-LTR circle formation',
+                        },
+                    ],
+                },
+            ],
+        })
+        
+        ret = database.get_matched_type_template(['Evaluation', 'Reactome', 'Concept'], {'only_toplevel': True})
+
+        assert len(ret) == 0
+        
+        ret = database.get_matched_type_template(['Evaluation', 'Reactome', 'Concept'], {'only_toplevel': False})
+
+        assert len(ret) == 1
     
     def test_get_matched_type(self, database: InMemoryDB):
         inheritance = database.get_matched_type('Inheritance')
         similarity = database.get_matched_type('Similarity')
         assert len(inheritance) == 12
         assert len(similarity) == 14
+    
+    def test_get_matched_type_only_toplevel(self, database: InMemoryDB):
+        database.add_link({
+            'type': 'EvaluationLink',
+            'targets': [
+                {'type': 'Predicate', 'name': 'Predicate:has_name'},
+                {
+                    'type': 'EvaluationLink',
+                    'targets': [
+                        {
+                            'type': 'Reactome',
+                            'name': 'Reactome:R-HSA-164843',
+                        },
+                        {
+                            'type': 'Concept',
+                            'name': 'Concept:2-LTR circle formation',
+                        },
+                    ],
+                },
+            ],
+        })
+        ret = database.get_matched_type('EvaluationLink')
+        assert len(ret) == 2
+
+        ret = database.get_matched_type('EvaluationLink', {'only_toplevel': True})
+        assert len(ret) == 1
 
     def test_get_node_name(self, database):
         handle = database.get_node_handle('Concept', 'monkey')

--- a/tests/adapters/test_redis_mongo_db.py
+++ b/tests/adapters/test_redis_mongo_db.py
@@ -589,6 +589,38 @@ arity_2_collection_mock_data = [
         'key_0': 'd03e59654221c1e8fcda404fd5c8d6cb',
         'key_1': '99d18c702e813b07260baf577c60c455',
     },
+    {
+        '_id': '1e8ba9639663105e6c735ba83174f789',
+        'composite_type': [
+            'b74a43dbb36287ea86eb5b0c7b86e8e8',
+            '79a5be2004199066acb26e7c1c963c29',
+            'd99a604c79ce3c2e76a2f43488d5d4c3',
+        ],
+        'composite_type_hash': '158e76774ba76f59ef774871252cfb7e',
+        'is_toplevel': False,
+        'key_0': '07508083e73bbc1e9ad513dd10a968ae',
+        'key_1': '24bc29bd87ecc3b3bc6c16c646506438',
+        'named_type': 'Evaluation',
+        'named_type_hash': 'b74a43dbb36287ea86eb5b0c7b86e8e8',
+    },
+    {
+        '_id': 'd542caa94b57219f1e489e3b03be7126',
+        'composite_type': [
+            'b74a43dbb36287ea86eb5b0c7b86e8e8',
+            '3b1b1a93a9b97ec3c8f2636fc6d54d0f',
+            [
+                'b74a43dbb36287ea86eb5b0c7b86e8e8',
+                '79a5be2004199066acb26e7c1c963c29',
+                'd99a604c79ce3c2e76a2f43488d5d4c3',
+            ],
+        ],
+        'composite_type_hash': '0ef46597d9234ad94b014af4a1997545',
+        'is_toplevel': True,
+        'key_0': 'a912032ece1826e55fa583dcaacdc4a9',
+        'key_1': '1e8ba9639663105e6c735ba83174f789',
+        'named_type': 'Evaluation',
+        'named_type_hash': 'b74a43dbb36287ea86eb5b0c7b86e8e8',
+    },
 ]
 
 outgoing_set_redis_mock_data = [
@@ -748,6 +780,24 @@ outgoing_set_redis_mock_data = [
             b'd03e59654221c1e8fcda404fd5c8d6cb',
         ]
     },
+    {
+        'outgoing_set:dc2891a1e8cb273c1c87b4b539615511': [
+            b'8a224e9b499baf68bf02a3f72335806c',
+            b'0ddefbdb97e354f36b694dfb5ae33922',
+        ]
+    },
+    {
+        'outgoing_set:ee8aa90f2f1b6eba761359fbf65ac39d': [
+            b'da8db3df47c6d03b44ed4d357715aeff',
+            b'dc2891a1e8cb273c1c87b4b539615511',
+        ]
+    },
+    {
+        'outgoing_set:b5c9e71594b40cd532b34baf0be29e11': [
+            b'da8db3df47c6d03b44ed4d357715aeff',
+            b'ee8aa90f2f1b6eba761359fbf65ac39d',
+        ]
+    },
 ]
 
 incomming_set_redis_mock_data = [
@@ -857,6 +907,32 @@ incomming_set_redis_mock_data = [
             '959924e3aab197af80a84c1ab261fd65',
             '116df61c01859c710d178ba14a483509',
             'b0f428929706d1d991e4d712ad08f9ab',
+        ]
+    },
+    {
+        'incomming_set:8a224e9b499baf68bf02a3f72335806c': [
+            'dc2891a1e8cb273c1c87b4b539615511'
+        ]
+    },
+    {
+        'incomming_set:0ddefbdb97e354f36b694dfb5ae33922': [
+            'dc2891a1e8cb273c1c87b4b539615511'
+        ]
+    },
+    {
+        'incomming_set:da8db3df47c6d03b44ed4d357715aeff': [
+            'ee8aa90f2f1b6eba761359fbf65ac39d',
+            'b5c9e71594b40cd532b34baf0be29e11',
+        ]
+    },
+    {
+        'incomming_set:dc2891a1e8cb273c1c87b4b539615511': [
+            'ee8aa90f2f1b6eba761359fbf65ac39d'
+        ]
+    },
+    {
+        'incomming_set:ee8aa90f2f1b6eba761359fbf65ac39d': [
+            'b5c9e71594b40cd532b34baf0be29e11'
         ]
     },
 ]
@@ -2316,6 +2392,128 @@ patterns_redis_mock_data = {
             ),
         )
     ],
+    "patterns:09d62c43e5ac4738fb2e38035d88cf79": [
+        (
+            'd542caa94b57219f1e489e3b03be7126',
+            (
+                'a912032ece1826e55fa583dcaacdc4a9',
+                '1e8ba9639663105e6c735ba83174f789',
+            ),
+        )
+    ],
+    'patterns:22b109cd4b54e8bc27cd3c399436bc8f': [
+        (
+            '1e8ba9639663105e6c735ba83174f789',
+            (
+                '07508083e73bbc1e9ad513dd10a968ae',
+                '24bc29bd87ecc3b3bc6c16c646506438',
+            ),
+        )
+    ],
+    'patterns:410fbee4b1683893342e748372cc0674': [
+        (
+            '1e8ba9639663105e6c735ba83174f789',
+            (
+                '07508083e73bbc1e9ad513dd10a968ae',
+                '24bc29bd87ecc3b3bc6c16c646506438',
+            ),
+        )
+    ],
+    'patterns:55bf38e5e6ae7091f87c6f540bfc1896': [
+        (
+            '1e8ba9639663105e6c735ba83174f789',
+            (
+                '07508083e73bbc1e9ad513dd10a968ae',
+                '24bc29bd87ecc3b3bc6c16c646506438',
+            ),
+        )
+    ],
+    'patterns:61e20b9d946843c0e391818f1a4e4fac': [
+        (
+            '1e8ba9639663105e6c735ba83174f789',
+            (
+                '07508083e73bbc1e9ad513dd10a968ae',
+                '24bc29bd87ecc3b3bc6c16c646506438',
+            ),
+        )
+    ],
+    'patterns:6e644e70a9fe3145c88b5b6261af5754': [
+        (
+            '1e8ba9639663105e6c735ba83174f789',
+            (
+                '07508083e73bbc1e9ad513dd10a968ae',
+                '24bc29bd87ecc3b3bc6c16c646506438',
+            ),
+        ),
+        (
+            'd542caa94b57219f1e489e3b03be7126',
+            (
+                'a912032ece1826e55fa583dcaacdc4a9',
+                '1e8ba9639663105e6c735ba83174f789',
+            ),
+        ),
+    ],
+    'patterns:7e4071137a69f147dde49f892cb8e61d': [
+        (
+            '1e8ba9639663105e6c735ba83174f789',
+            (
+                '07508083e73bbc1e9ad513dd10a968ae',
+                '24bc29bd87ecc3b3bc6c16c646506438',
+            ),
+        )
+    ],
+    'patterns:8721a229b5cad6403828924cbdd726a4': [
+        (
+            'd542caa94b57219f1e489e3b03be7126',
+            (
+                'a912032ece1826e55fa583dcaacdc4a9',
+                '1e8ba9639663105e6c735ba83174f789',
+            ),
+        )
+    ],
+    'patterns:bcc291dd0778be127bec52ee2e28ac84': [
+        (
+            'd542caa94b57219f1e489e3b03be7126',
+            (
+                'a912032ece1826e55fa583dcaacdc4a9',
+                '1e8ba9639663105e6c735ba83174f789',
+            ),
+        )
+    ],
+    'patterns:d23673920e8289897273316a1331048e': [
+        (
+            'd542caa94b57219f1e489e3b03be7126',
+            (
+                'a912032ece1826e55fa583dcaacdc4a9',
+                '1e8ba9639663105e6c735ba83174f789',
+            ),
+        )
+    ],
+    'patterns:e48c0b4d17a514cb58a75c789eb8bb14': [
+        (
+            'd542caa94b57219f1e489e3b03be7126',
+            (
+                'a912032ece1826e55fa583dcaacdc4a9',
+                '1e8ba9639663105e6c735ba83174f789',
+            ),
+        )
+    ],
+    'patterns:fc55eaf3fe4af40321a3bec94e50fd5b': [
+        (
+            '1e8ba9639663105e6c735ba83174f789',
+            (
+                '07508083e73bbc1e9ad513dd10a968ae',
+                '24bc29bd87ecc3b3bc6c16c646506438',
+            ),
+        ),
+        (
+            'd542caa94b57219f1e489e3b03be7126',
+            (
+                'a912032ece1826e55fa583dcaacdc4a9',
+                '1e8ba9639663105e6c735ba83174f789',
+            ),
+        ),
+    ],
 }
 
 templates_redis_mock_data = {
@@ -2691,6 +2889,40 @@ templates_redis_mock_data = {
             ),
         ),
     ],
+    'templates:158e76774ba76f59ef774871252cfb7e': [
+        (
+            '1e8ba9639663105e6c735ba83174f789',
+            (
+                '07508083e73bbc1e9ad513dd10a968ae',
+                '24bc29bd87ecc3b3bc6c16c646506438',
+            ),
+        )
+    ],
+    "templates:b74a43dbb36287ea86eb5b0c7b86e8e8": [
+        (
+            '1e8ba9639663105e6c735ba83174f789',
+            (
+                '07508083e73bbc1e9ad513dd10a968ae',
+                '24bc29bd87ecc3b3bc6c16c646506438',
+            ),
+        ),
+        (
+            'd542caa94b57219f1e489e3b03be7126',
+            (
+                'a912032ece1826e55fa583dcaacdc4a9',
+                '1e8ba9639663105e6c735ba83174f789',
+            ),
+        ),
+    ],
+    'templates:0ef46597d9234ad94b014af4a1997545': [
+        (
+            'd542caa94b57219f1e489e3b03be7126',
+            (
+                'a912032ece1826e55fa583dcaacdc4a9',
+                '1e8ba9639663105e6c735ba83174f789',
+            ),
+        )
+    ],
 }
 
 names_redis_mock_data = {
@@ -2782,13 +3014,15 @@ class TestRedisMongoDB:
                     ):
                         ret.append(node)
                 return ret
-            
+
         def estimated_document_count():
             return len(node_collection_mock_data)
 
         collection.find_one = mock.Mock(side_effect=find_one)
         collection.find = mock.Mock(side_effect=find)
-        collection.estimated_document_count = mock.Mock(side_effect=estimated_document_count)
+        collection.estimated_document_count = mock.Mock(
+            side_effect=estimated_document_count
+        )
         return collection
 
     @pytest.fixture()
@@ -2824,7 +3058,9 @@ class TestRedisMongoDB:
             return len([])
 
         collection.find = mock.Mock(side_effect=find)
-        collection.estimated_document_count = mock.Mock(side_effect=estimated_document_count)
+        collection.estimated_document_count = mock.Mock(
+            side_effect=estimated_document_count
+        )
         return collection
 
     @pytest.fixture()
@@ -2850,7 +3086,9 @@ class TestRedisMongoDB:
 
         collection.find_one = mock.Mock(side_effect=find_one)
         collection.find = mock.Mock(side_effect=find)
-        collection.estimated_document_count = mock.Mock(side_effect=estimated_document_count)
+        collection.estimated_document_count = mock.Mock(
+            side_effect=estimated_document_count
+        )
 
         return collection
 
@@ -2871,7 +3109,9 @@ class TestRedisMongoDB:
             return len([])
 
         collection.find = mock.Mock(side_effect=find)
-        collection.estimated_document_count = mock.Mock(side_effect=estimated_document_count)
+        collection.estimated_document_count = mock.Mock(
+            side_effect=estimated_document_count
+        )
         return collection
 
     @pytest.fixture()
@@ -3057,6 +3297,23 @@ class TestRedisMongoDB:
 
         assert expected == actual[0]
 
+    def test_get_matched_links_only_toplevel(self, database):
+        expected = [
+            (
+                'd542caa94b57219f1e489e3b03be7126',
+                (
+                    'a912032ece1826e55fa583dcaacdc4a9',
+                    '1e8ba9639663105e6c735ba83174f789',
+                ),
+            )
+        ]
+        actual = database.get_matched_links(
+            'Evaluation', ['*', '*'], {'only_toplevel': True}
+        )
+
+        assert expected == actual
+        assert len(actual) == 1
+
     def test_get_all_nodes(self, database):
         ret = database.get_all_nodes('Concept')
         assert len(ret) == 14
@@ -3114,6 +3371,14 @@ class TestRedisMongoDB:
         assert len(inheritance[0]) == 12
         assert len(similarity[0]) == 14
 
+    def test_get_matched_type_only_toplevel(self, database):
+        ret = database.get_matched_type('Evaluation')
+        assert len(ret[0]) == 2
+
+        ret = database.get_matched_type('Evaluation', {'only_toplevel': True})
+
+        assert len(ret) == 1
+
     def test_get_node_name(self, database):
         node_type = 'Concept'
         node_name = 'monkey'
@@ -3152,7 +3417,7 @@ class TestRedisMongoDB:
         expected = {'handle': human_handle, 'type': 'Concept', 'name': 'human'}
         actual = database.get_atom_as_dict(human_handle)
         assert expected == actual
-    
+
     # def test_get_atom_as_dict_node_without_cache(self, database):
     #     from hyperon_das_atomdb.adapters import redis_mongo_db
 
@@ -3211,7 +3476,7 @@ class TestRedisMongoDB:
         link_handle = database.get_link_handle('Similarity', [human, chimp])
         resp_link = database.get_link_type(link_handle)
         assert 'Similarity' == resp_link
-        
+
     def test_get_link_type_without_cache(self, database):
         from hyperon_das_atomdb.adapters import redis_mongo_db
 
@@ -3225,242 +3490,4 @@ class TestRedisMongoDB:
     def test_atom_count(self, database):
         node_count, link_count = database.count_atoms()
         assert node_count == 14
-        assert link_count == 26
-
-    # def test_db_creation(self, db: RedisMongoDB):
-    #     assert db.redis is not None
-    #     assert db.mongo_db is not None
-    #     assert db.node_documents.size() == 14
-    #     assert len(db.named_type_hash) == 18
-    #     assert len(db.named_type_hash_reverse) == 18
-    #     assert len(db.named_types) == 18
-    #     assert len(db.symbol_hash) == 18
-    #     assert len(db.parent_type) == 18
-
-    # NODE_SPECS = [
-    #     ('Concept', 'human'),
-    #     ('Concept', 'monkey'),
-    #     ('Concept', 'chimp'),
-    #     ('Concept', 'snake'),
-    #     ('Concept', 'earthworm'),
-    #     ('Concept', 'rhino'),
-    #     ('Concept', 'triceratops'),
-    #     ('Concept', 'vine'),
-    #     ('Concept', 'ent'),
-    #     ('Concept', 'mammal'),
-    #     ('Concept', 'animal'),
-    #     ('Concept', 'reptile'),
-    #     ('Concept', 'dinosaur'),
-    #     ('Concept', 'plant'),
-    # ]
-
-    # def _add_node_names(db, txt):
-    #     handles = re.findall("'[a-z0-9]{32}'", txt)
-    #     for quoted_handle in handles:
-    #         handle = quoted_handle[1:-1]
-    #         try:
-    #             node_name = db.get_node_name(handle)
-    #             txt = re.sub(
-    #                 quoted_handle, f'{quoted_handle} ({node_name})', txt, count=1
-    #             )
-    #         except Exception:
-    #             pass
-    #     return txt
-
-    # def test_node_exists(db: IAtomDB):
-    #     assert db.node_exists('Concept', 'human')
-    #     assert db.node_exists('Concept', 'monkey')
-    #     assert db.node_exists('Concept', 'chimp')
-    #     assert db.node_exists('Concept', 'snake')
-    #     assert db.node_exists('Concept', 'earthworm')
-    #     assert db.node_exists('Concept', 'rhino')
-    #     assert db.node_exists('Concept', 'triceratops')
-    #     assert db.node_exists('Concept', 'vine')
-    #     assert db.node_exists('Concept', 'ent')
-    #     assert db.node_exists('Concept', 'mammal')
-    #     assert db.node_exists('Concept', 'animal')
-    #     assert db.node_exists('Concept', 'reptile')
-    #     assert db.node_exists('Concept', 'dinosaur')
-    #     assert db.node_exists('Concept', 'plant')
-    #     assert not db.node_exists('blah', 'plant')
-    #     assert not db.node_exists('Concept', 'blah')
-
-    # def _check_link(
-    #     db: IAtomDB, handle: str, link_type: str, target1: str, target2: str
-    # ):
-    #     collection = db.mongo_db.get_collection(MongoCollectionNames.LINKS_ARITY_2)
-    #     document = collection.find_one({'_id': handle})
-    #     type_handle = db.named_type_hash[link_type]
-    #     assert document
-    #     assert document['named_type_hash'] == type_handle
-    #     assert document['key_0'] == target1
-    #     assert document['key_1'] == target2
-
-    # def _get_mongo_document(db: IAtomDB, handle: str):
-    #     collection = db.mongo_db.get_collection(MongoCollectionNames.LINKS_ARITY_2)
-    #     document = collection.find_one({'_id': handle})
-    #     return document
-
-    # def test_get_link_handle(db: IAtomDB):
-    #     human = db.get_node_handle('Concept', 'human')
-    #     monkey = db.get_node_handle('Concept', 'monkey')
-    #     mammal = db.get_node_handle('Concept', 'mammal')
-    #     handle = db.get_link_handle('Inheritance', [human, mammal])
-    #     _check_link(db, handle, 'Inheritance', human, mammal)
-    #     handle = db.get_link_handle('Inheritance', [monkey, mammal])
-    #     _check_link(db, handle, 'Inheritance', monkey, mammal)
-    #     handle = db.get_link_handle('Similarity', [human, monkey])
-    #     _check_link(db, handle, 'Similarity', human, monkey)
-    #     handle = db.get_link_handle('Similarity', [monkey, human])
-    #     _check_link(db, handle, 'Similarity', monkey, human)
-
-    # def test_link_exists(db: IAtomDB):
-    #     human = db.get_node_handle('Concept', 'human')
-    #     monkey = db.get_node_handle('Concept', 'monkey')
-    #     mammal = db.get_node_handle('Concept', 'mammal')
-    #     assert db.link_exists('Inheritance', [human, mammal])
-    #     assert db.link_exists('Inheritance', [monkey, mammal])
-    #     assert not db.link_exists('Inheritance', [monkey, human])
-    #     assert db.link_exists('Similarity', [human, monkey])
-    #     assert db.link_exists('Similarity', [monkey, human])
-    #     assert not db.link_exists('Similarity', [mammal, human])
-    #     assert not db.link_exists('Similarity', [human, mammal])
-
-    # def test_get_node_handle(db: IAtomDB):
-    #     node_names = [
-    #         'human',
-    #         'monkey',
-    #         'chimp',
-    #         'snake',
-    #         'earthworm',
-    #         'rhino',
-    #         'triceratops',
-    #         'vine',
-    #         'ent',
-    #         'mammal',
-    #         'animal',
-    #         'reptile',
-    #         'dinosaur',
-    #         'plant',
-    #     ]
-    #     for name in node_names:
-    #         handle = db.get_node_handle('Concept', name)
-    #         collection = db.mongo_db.get_collection(MongoCollectionNames.NODES)
-    #         document = collection.find_one({'_id': handle})
-    #         assert document[MongoFieldNames.NODE_NAME] == name
-
-    # def _check_link_targets(
-    #     db: IAtomDB, handle: str, target_handles: List[str], ordered: bool
-    # ):
-    #     assert len(target_handles) == 2
-    #     document = _get_mongo_document(db, handle)
-    #     if ordered:
-    #         assert document['key_0'] == target_handles[0]
-    #         assert document['key_1'] == target_handles[1]
-    #     else:
-    #         assert (
-    #             document['key_0'] == target_handles[0]
-    #             and document['key_1'] == target_handles[1]
-    #         ) or (
-    #             document['key_0'] == target_handles[1]
-    #             and document['key_1'] == target_handles[0]
-    #         )
-
-    # def test_get_link_targets(db: IAtomDB):
-    #     human = db.get_node_handle('Concept', 'human')
-    #     monkey = db.get_node_handle('Concept', 'monkey')
-    #     mammal = db.get_node_handle('Concept', 'mammal')
-    #     handle = db.get_link_handle('Inheritance', [human, mammal])
-    #     _check_link_targets(db, handle, [human, mammal], True)
-    #     with pytest.raises(AssertionError):
-    #         _check_link_targets(db, handle, [mammal, human], True)
-    #     handle = db.get_link_handle('Inheritance', [monkey, mammal])
-    #     _check_link_targets(db, handle, [monkey, mammal], True)
-    #     with pytest.raises(AssertionError):
-    #         _check_link_targets(db, handle, [mammal, monkey], True)
-    #     with pytest.raises(AssertionError):
-    #         _check_link_targets(db, handle, [monkey, monkey], True)
-    #     handle = db.get_link_handle('Similarity', [human, monkey])
-    #     _check_link_targets(db, handle, [human, monkey], False)
-    #     _check_link_targets(db, handle, [monkey, human], False)
-    #     handle = db.get_link_handle('Similarity', [monkey, human])
-    #     _check_link_targets(db, handle, [human, monkey], False)
-    #     _check_link_targets(db, handle, [monkey, human], False)
-    #     with pytest.raises(AssertionError):
-    #         _check_link_targets(db, handle, [monkey, mammal], False)
-    #     with pytest.raises(AssertionError):
-    #         _check_link_targets(db, handle, [mammal, monkey], False)
-
-    # def test_is_ordered(db: IAtomDB):
-    #     human = db.get_node_handle('Concept', 'human')
-    #     monkey = db.get_node_handle('Concept', 'monkey')
-    #     mammal = db.get_node_handle('Concept', 'mammal')
-    #     assert db.is_ordered(db.get_link_handle('Inheritance', [human, mammal]))
-    #     assert db.is_ordered(db.get_link_handle('Similarity', [human, monkey]))
-    #     with pytest.raises(ValueError):
-    #         db.is_ordered(db.get_link_handle('Inheritance', [human, monkey]))
-
-    # def test_get_all_nodes(db: IAtomDB):
-    #     nodes_in_db = db.get_all_nodes('Concept')
-    #     assert len(nodes_in_db) == 14
-    #     for node_type, node_name in NODE_SPECS:
-    #         node = db.get_node_handle(node_type, node_name)
-    #         assert node in nodes_in_db
-    #     nodes_in_db = db.get_all_nodes('blah')
-    #     assert len(nodes_in_db) == 0
-
-    # def test_get_matched_links(db: IAtomDB):
-    #     mammal = db.get_node_handle('Concept', 'mammal')
-    #     animal = db.get_node_handle('Concept', 'animal')
-    #     human = db.get_node_handle('Concept', 'human')
-    #     monkey = db.get_node_handle('Concept', 'monkey')
-    #     chimp = db.get_node_handle('Concept', 'chimp')
-    #     assert len(db.get_matched_links('Inheritance', ['*', '*'])) == 12
-    #     assert len(db.get_matched_links('Inheritance', ['*', mammal])) == 4
-    #     assert len(db.get_matched_links('Inheritance', [mammal, '*'])) == 1
-    #     assert len(db.get_matched_links('Inheritance', ['*', animal])) == 3
-    #     assert len(db.get_matched_links('Inheritance', [animal, '*'])) == 0
-    #     assert len(db.get_matched_links('Inheritance', [mammal, animal])) == 1
-    #     assert len(db.get_matched_links('Inheritance', [chimp, mammal])) == 1
-    #     assert len(db.get_matched_links('Inheritance', [animal, mammal])) == 0
-    #     assert len(db.get_matched_links('Similarity', ['*', '*'])) == 14
-    #     assert len(db.get_matched_links('Similarity', [human, '*'])) == 3
-    #     assert len(db.get_matched_links('Similarity', ['*', human])) == 3
-    #     assert len(db.get_matched_links('Similarity', [monkey, '*'])) == 2
-    #     assert len(db.get_matched_links('Similarity', ['*', monkey])) == 2
-    #     assert len(db.get_matched_links('Similarity', [chimp, '*'])) == 2
-    #     assert len(db.get_matched_links('Similarity', ['*', chimp])) == 2
-    #     assert len(db.get_matched_links('Similarity', [monkey, human])) == 1
-    #     assert len(db.get_matched_links('Similarity', [human, monkey])) == 1
-    #     assert len(db.get_matched_links('Similarity', [human, mammal])) == 0
-    #     assert len(db.get_matched_links('Similarity', [mammal, human])) == 0
-
-    # def test_build_hash_template(db: IAtomDB):
-    #     v1 = db._build_named_type_hash_template(
-    #         ['Inheritance', 'Concept', 'Concept']
-    #     )
-    #     v2 = db._build_named_type_hash_template(
-    #         ['Similarity', 'Concept', 'Concept']
-    #     )
-    #     v3 = db._build_named_type_hash_template(
-    #         ['Similarity', 'Concept', ['Inheritance', 'Concept', 'Concept']]
-    #     )
-    #     assert len(v1) == 3
-    #     assert len(v2) == 3
-    #     assert len(v3) == 3
-    #     assert len(v3[2]) == 3
-    #     assert v1[1] == v1[2] and v1[0] != v1[1]
-    #     assert v2[1] == v2[2] and v2[0] != v2[1]
-    #     assert v1[0] != v2[0] and v1[1] == v2[1]
-    #     assert v3[0] == v2[0]
-    #     assert v3[1] == v1[1]
-    #     assert v3[2][0] == v1[0]
-    #     assert v3[2][1] == v1[1]
-    #     assert v3[2][2] == v1[2]
-
-    # def test_get_node_name(db: IAtomDB):
-    #     for node_type, node_name in NODE_SPECS:
-    #         handle = db.get_node_handle(node_type, node_name)
-    #         db_name = db.get_node_name(handle)
-    #         assert db_name == node_name
-
+        assert link_count == 28


### PR DESCRIPTION
In this branch, a parameter called `extra_parameters` was added to some methods of the `InMemoryDB` and `RedisMongoDB` classes. The goal is to filter matches if the '`only_toplevel'` parameter is sent