### PR TITLE
Remove "i" prefix of i_database.py and IAtomDB

### DIFF
--- a/hyperon_das_atomdb/__init__.py
+++ b/hyperon_das_atomdb/__init__.py
@@ -1,3 +1,3 @@
-from .i_database import UNORDERED_LINK_TYPES, WILDCARD, IAtomDB
+from .database import UNORDERED_LINK_TYPES, WILDCARD, AtomDB
 
-__all__ = ['IAtomDB', 'WILDCARD', 'UNORDERED_LINK_TYPES']
+__all__ = ['AtomDB', 'WILDCARD', 'UNORDERED_LINK_TYPES']

--- a/hyperon_das_atomdb/adapters/ram_only.py
+++ b/hyperon_das_atomdb/adapters/ram_only.py
@@ -8,16 +8,16 @@ from hyperon_das_atomdb.exceptions import (
     LinkDoesNotExistException,
     NodeDoesNotExistException,
 )
-from hyperon_das_atomdb.i_database import (
+from hyperon_das_atomdb.database import (
     UNORDERED_LINK_TYPES,
     WILDCARD,
-    IAtomDB,
+    AtomDB,
 )
 from hyperon_das_atomdb.utils.expression_hasher import ExpressionHasher
 from hyperon_das_atomdb.utils.patterns import build_patern_keys
 
 
-class InMemoryDB(IAtomDB):
+class InMemoryDB(AtomDB):
     """A concrete implementation using hashtable (dict)"""
 
     def __repr__(self) -> str:

--- a/hyperon_das_atomdb/adapters/redis_mongo_db.py
+++ b/hyperon_das_atomdb/adapters/redis_mongo_db.py
@@ -20,10 +20,10 @@ from hyperon_das_atomdb.exceptions import (
     LinkDoesNotExistException,
     NodeDoesNotExistException,
 )
-from hyperon_das_atomdb.i_database import (
+from hyperon_das_atomdb.database import (
     UNORDERED_LINK_TYPES,
     WILDCARD,
-    IAtomDB,
+    AtomDB,
 )
 from hyperon_das_atomdb.logger import logger
 from hyperon_das_atomdb.utils.expression_hasher import ExpressionHasher
@@ -72,7 +72,7 @@ class NodeDocuments:
             yield document
 
 
-class RedisMongoDB(IAtomDB):
+class RedisMongoDB(AtomDB):
     """A concrete implementation using Redis and Mongo database"""
 
     def __repr__(self) -> str:

--- a/hyperon_das_atomdb/adapters/server_db.py
+++ b/hyperon_das_atomdb/adapters/server_db.py
@@ -7,12 +7,12 @@ from hyperon_das_atomdb.exceptions import (
     ConnectionServerException,
     NodeDoesNotExistException,
 )
-from hyperon_das_atomdb.i_database import IAtomDB
+from hyperon_das_atomdb.database import AtomDB
 from hyperon_das_atomdb.utils.decorators import retry
 from hyperon_das_atomdb.utils.settings import config
 
 
-class ServerDB(IAtomDB):
+class ServerDB(AtomDB):
     """A concrete implementation using servers databases.
     AwsLambda and OpenFaas"""
 

--- a/hyperon_das_atomdb/database.py
+++ b/hyperon_das_atomdb/database.py
@@ -11,13 +11,13 @@ WILDCARD = '*'
 UNORDERED_LINK_TYPES = []
 
 
-class IAtomDB(ABC):
+class AtomDB(ABC):
     def __repr__(self) -> str:
         """
         Magic method for string representation of the class.
-        Returns a string representation of the IAtomDB class.
+        Returns a string representation of the AtomDB class.
         """
-        return "<Atom database interface>"  # pragma no cover
+        return "<Atom database abstract class>"  # pragma no cover
 
     def _node_handle(self, node_type: str, node_name: str) -> str:
         return ExpressionHasher.terminal_hash(node_type, node_name)

--- a/hyperon_das_atomdb/utils/patterns.py
+++ b/hyperon_das_atomdb/utils/patterns.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from hyperon_das_atomdb.i_database import WILDCARD
+from hyperon_das_atomdb.database import WILDCARD
 from hyperon_das_atomdb.utils.expression_hasher import ExpressionHasher
 
 # def generate_binary_matrix(numbers: int) -> list:

--- a/tests/unit/adapters/test_redis_mongo_db.py
+++ b/tests/unit/adapters/test_redis_mongo_db.py
@@ -23,7 +23,6 @@ from hyperon_das_atomdb.exceptions import (
     LinkDoesNotExistException,
     NodeDoesNotExistException,
 )
-from hyperon_das_atomdb.i_database import IAtomDB
 from hyperon_das_atomdb.utils.expression_hasher import ExpressionHasher
 
 node_collection_mock_data = [


### PR DESCRIPTION
AtomDB is no longer an interface as it contains concrete methods.

This is part of the work for https://github.com/singnet/das-atom-db/issues/43