### PR TITLE
[HOTFIX] Add 'type' in documents returned by get_atom()

### DIFF
--- a/hyperon_das_atomdb/database.py
+++ b/hyperon_das_atomdb/database.py
@@ -36,7 +36,7 @@ class AtomDB(ABC):
     def _convert_atom_format(
         self, document: Dict[str, Any], **kwargs
     ) -> Union[Tuple[Dict[str, Any], List[Dict[str, Any]]], Dict[str, Any]]:
-        answer = {'handle': document['_id']}
+        answer = {'handle': document['_id'], 'type': document['named_type']}
 
         for key, value in document.items():
             if key == '_id':


### PR DESCRIPTION
Resolves #91 
Required by https://github.com/singnet/das-query-engine/issues/120