### PR TITLE
[#96] Adjust retrieve methods for sets in Redis - incoming_set, templates, patterns

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,3 +3,4 @@
 [HOTFIX] Add 'type' in documents returned by get_atom()
 [#84] Add delete_atom method in the InMemoryDB adapter
 [#85] Add delete_atom method in the RedisMongoDB adapter
+[#106] Adjust retrieve methods for sets in Redis - incoming_set, templates, patterns

--- a/hyperon_das_atomdb/adapters/ram_only.py
+++ b/hyperon_das_atomdb/adapters/ram_only.py
@@ -345,7 +345,7 @@ class InMemoryDB(AtomDB):
         self,
         link_type: str,
         target_handles: List[str],
-        extra_parameters: Optional[Dict[str, Any]] = None,
+        **kwargs: Optional[Dict[str, Any]],
     ) -> list:
         if link_type != WILDCARD and WILDCARD not in target_handles:
             link_handle = self.get_link_handle(link_type, target_handles)
@@ -371,7 +371,7 @@ class InMemoryDB(AtomDB):
         patterns_matched = self.db.patterns.get(pattern_hash, [])
 
         if len(patterns_matched) > 0:
-            if extra_parameters and extra_parameters.get('toplevel_only'):
+            if kwargs.get('toplevel_only'):
                 return self._filter_non_toplevel(patterns_matched)
 
         return patterns_matched
@@ -394,23 +394,21 @@ class InMemoryDB(AtomDB):
     def get_matched_type_template(
         self,
         template: List[Any],
-        extra_parameters: Optional[Dict[str, Any]] = None,
+        **kwargs: Optional[Dict[str, Any]],
     ) -> List[str]:
         template = self._build_named_type_hash_template(template)
         template_hash = ExpressionHasher.composite_hash(template)
         templates_matched = self.db.templates.get(template_hash, [])
         if len(templates_matched) > 0:
-            if extra_parameters and extra_parameters.get('toplevel_only'):
+            if kwargs.get('toplevel_only'):
                 return self._filter_non_toplevel(templates_matched)
         return templates_matched
 
-    def get_matched_type(
-        self, link_type: str, extra_parameters: Optional[Dict[str, Any]] = None
-    ) -> List[str]:
+    def get_matched_type(self, link_type: str, **kwargs: Optional[Dict[str, Any]]) -> List[str]:
         link_type_hash = ExpressionHasher.named_type_hash(link_type)
         templates_matched = self.db.templates.get(link_type_hash, [])
         if len(templates_matched) > 0:
-            if extra_parameters and extra_parameters.get('toplevel_only'):
+            if kwargs.get('toplevel_only'):
                 return self._filter_non_toplevel(templates_matched)
         return templates_matched
 

--- a/hyperon_das_atomdb/adapters/redis_mongo_db.py
+++ b/hyperon_das_atomdb/adapters/redis_mongo_db.py
@@ -680,7 +680,7 @@ class RedisMongoDB(AtomDB):
                 chunk_size (int, optional): The size of each chunk to retrieve.
 
         Returns:
-            list: A list of members retrieved from Redis.
+            Tuple[int, list]: The cursor and a list of members retrieved from Redis.
         """
         if (cursor := kwargs.get('cursor')) is not None:
             chunk_size = kwargs.get('chunk_size', 1000)

--- a/tests/unit/adapters/test_ram_only.py
+++ b/tests/unit/adapters/test_ram_only.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 import pytest
 
 from hyperon_das_atomdb import AtomDB
@@ -12,7 +10,6 @@ from hyperon_das_atomdb.exceptions import (
     NodeDoesNotExist,
 )
 from hyperon_das_atomdb.utils.expression_hasher import ExpressionHasher
-from hyperon_das_atomdb.utils.patterns import build_patern_keys
 
 
 class TestInMemoryDB:
@@ -397,7 +394,7 @@ class TestInMemoryDB:
                 ),
             )
         ]
-        actual = database.get_matched_links('Evaluation', ['*', '*'], {'toplevel_only': True})
+        actual = database.get_matched_links('Evaluation', ['*', '*'], toplevel_only=True)
 
         assert expected == actual
         assert len(actual) == 1
@@ -433,7 +430,7 @@ class TestInMemoryDB:
                 ],
             }
         )
-        actual = database.get_matched_links('Evaluation', ['*', '*'], {'toplevel': True})
+        actual = database.get_matched_links('Evaluation', ['*', '*'], toplevel=True)
 
         assert len(actual) == 2
 
@@ -483,13 +480,13 @@ class TestInMemoryDB:
         )
 
         ret = database.get_matched_type_template(
-            ['Evaluation', 'Reactome', 'Concept'], {'toplevel_only': True}
+            ['Evaluation', 'Reactome', 'Concept'], toplevel_only=True
         )
 
         assert len(ret) == 0
 
         ret = database.get_matched_type_template(
-            ['Evaluation', 'Reactome', 'Concept'], {'toplevel_only': False}
+            ['Evaluation', 'Reactome', 'Concept'], toplevel_only=False
         )
 
         assert len(ret) == 1
@@ -525,7 +522,7 @@ class TestInMemoryDB:
         ret = database.get_matched_type('EvaluationLink')
         assert len(ret) == 2
 
-        ret = database.get_matched_type('EvaluationLink', {'toplevel_only': True})
+        ret = database.get_matched_type('EvaluationLink', toplevel_only=True)
         assert len(ret) == 1
 
     def test_get_node_name(self, database):

--- a/tests/unit/adapters/test_redis_mongo_db.py
+++ b/tests/unit/adapters/test_redis_mongo_db.py
@@ -3349,7 +3349,7 @@ class TestRedisMongoDB:
                 ),
             )
         ]
-        actual = database.get_matched_links('Evaluation', ['*', '*'], {'toplevel_only': True})
+        actual = database.get_matched_links('Evaluation', ['*', '*'], toplevel_only=True)
 
         assert expected == actual
         assert len(actual) == 1
@@ -3395,7 +3395,7 @@ class TestRedisMongoDB:
         ret = database.get_matched_type('Evaluation')
         assert len(ret[0]) == 2
 
-        ret = database.get_matched_type('Evaluation', {'toplevel_only': True})
+        ret = database.get_matched_type('Evaluation', toplevel_only=True)
 
         assert len(ret) == 1
 


### PR DESCRIPTION
Changes:

- Add a private method to retrieve members set in Redis `_get_redis_members`
- Change the return of the methods `_retrieve_incoming_set`, `_retrieve_template`, `_retrieve_pattern`
- Change the `extra_parameters` parameter to `kwargs`

Resolves #96 