### PR TITLE
[das#226] Add optional parameter to count atoms

### DIFF
--- a/hyperon_das_atomdb/adapters/ram_only.py
+++ b/hyperon_das_atomdb/adapters/ram_only.py
@@ -491,8 +491,11 @@ class InMemoryDB(AtomDB):
             details=f"handle: {handle}",
         )
 
-    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Tuple[int, int]:
-        return len(self.db.node), len(self.db.link)
+    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Dict[str, int]:
+        node_count = len(self.db.node)
+        link_count = len(self.db.link)
+        atom_count = node_count + link_count
+        return {'atom_count': atom_count, 'node_count': node_count, 'link_count': link_count}
 
     def clear_database(self) -> None:
         self.named_type_table = {}

--- a/hyperon_das_atomdb/adapters/ram_only.py
+++ b/hyperon_das_atomdb/adapters/ram_only.py
@@ -491,7 +491,7 @@ class InMemoryDB(AtomDB):
             details=f"handle: {handle}",
         )
 
-    def count_atoms(self) -> Tuple[int, int]:
+    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Tuple[int, int]:
         return len(self.db.node), len(self.db.link)
 
     def clear_database(self) -> None:

--- a/hyperon_das_atomdb/adapters/redis_mongo_db.py
+++ b/hyperon_das_atomdb/adapters/redis_mongo_db.py
@@ -615,17 +615,21 @@ class RedisMongoDB(AtomDB):
                 answer["name"] = document["name"]
         return answer
 
-    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Tuple[int, int]:
-        if parameters and parameters.get('precision') == 'precise':
+    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Dict[str, int]:
+        atom_count = self.mongo_atoms_collection.estimated_document_count()
+        return_count = {'atom_count': atom_count, 'node_count': 0, 'link_count': 0}
+        if parameters and parameters.get('precise'):
             nodes_count = self.mongo_atoms_collection.count_documents(
                 {FieldNames.COMPOSITE_TYPE: {'$exists': False}}
             )
             links_count = self.mongo_atoms_collection.count_documents(
                 {FieldNames.COMPOSITE_TYPE: {'$exists': True}}
             )
-            return nodes_count, links_count
+            return_count['node_count'] = nodes_count
+            return_count['link_count'] = links_count
+            return return_count
 
-        return self.mongo_atoms_collection.estimated_document_count(), 0
+        return return_count
 
     def clear_database(self) -> None:
         """

--- a/hyperon_das_atomdb/adapters/redis_mongo_db.py
+++ b/hyperon_das_atomdb/adapters/redis_mongo_db.py
@@ -617,7 +617,7 @@ class RedisMongoDB(AtomDB):
 
     def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Dict[str, int]:
         atom_count = self.mongo_atoms_collection.estimated_document_count()
-        return_count = {'atom_count': atom_count, 'node_count': 0, 'link_count': 0}
+        return_count = {'atom_count': atom_count}
         if parameters and parameters.get('precise'):
             nodes_count = self.mongo_atoms_collection.count_documents(
                 {FieldNames.COMPOSITE_TYPE: {'$exists': False}}

--- a/hyperon_das_atomdb/adapters/redis_mongo_db.py
+++ b/hyperon_das_atomdb/adapters/redis_mongo_db.py
@@ -615,14 +615,17 @@ class RedisMongoDB(AtomDB):
                 answer["name"] = document["name"]
         return answer
 
-    def count_atoms(self) -> Tuple[int, int]:
-        nodes_count = self.mongo_atoms_collection.count_documents(
-            {FieldNames.COMPOSITE_TYPE: {'$exists': False}}
-        )
-        links_count = self.mongo_atoms_collection.count_documents(
-            {FieldNames.COMPOSITE_TYPE: {'$exists': True}}
-        )
-        return (nodes_count, links_count)
+    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Tuple[int, int]:
+        if parameters and parameters.get('precision') == 'precise':
+            nodes_count = self.mongo_atoms_collection.count_documents(
+                {FieldNames.COMPOSITE_TYPE: {'$exists': False}}
+            )
+            links_count = self.mongo_atoms_collection.count_documents(
+                {FieldNames.COMPOSITE_TYPE: {'$exists': True}}
+            )
+            return nodes_count, links_count
+
+        return self.mongo_atoms_collection.estimated_document_count(), 0
 
     def clear_database(self) -> None:
         """

--- a/hyperon_das_atomdb/database.py
+++ b/hyperon_das_atomdb/database.py
@@ -529,17 +529,18 @@ class AtomDB(ABC):
     def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Dict[str, int]:
         """
         Count the total number of atoms in the database.
-        If the optional parameter 'precise' is set to True returns the node count and link count (slow).
+        If the optional parameter 'precise' is set to True returns the node count and link count (slow), otherwise
+        return the atom_count.
 
         Args:
-            parameters (Optional[Dict[str, Any]]): Dict containing the following key 'precise' - sets the count
-                precision as 'precise' if True or 'fast' if False. Default value for 'precise' is False.
+            parameters (Optional[Dict[str, Any]]): An optional dictionary containing the following key:
+                'precise' (bool, optional)  If set to True, the count provides an accurate count but may be slower.
+                If set to False, the count will be an estimate, which is faster but less precise.
                 Defaults to None.
 
         Returns:
-            Dict[str, int]: A dict containing str keys and integers, where the key 'node_count' has an integer which is
-                the count of node atoms, the key 'link_count' is the count of link atoms and 'atom_count' is the count
-                of all atoms.
+            Dict[str, int]:A dictionary containing the following keys: 'node_count' (int): The count of node atoms;
+                'link_count' (int): The count of link atoms; 'atom_count' (int): The total count of all atoms;
         """
         ...  # pragma no cover
 

--- a/hyperon_das_atomdb/database.py
+++ b/hyperon_das_atomdb/database.py
@@ -526,12 +526,16 @@ class AtomDB(ABC):
         ...  # pragma no cover
 
     @abstractmethod
-    def count_atoms(self):
+    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Tuple[int, int]:
         """
         Count the total number of atoms in the database.
 
+        Args:
+            parameters (Optional[Dict[str, Any]]): Dict containing the following key 'precision' - sets the count
+                precision as 'precise' or 'fast'. Default value for 'precision' is 'fast'. Defaults to None.
+
         Returns:
-            [return-type]: The return type description (not specified in the code).
+            Tuple[int, int]: (node_count, link_count).
         """
         ...  # pragma no cover
 

--- a/hyperon_das_atomdb/database.py
+++ b/hyperon_das_atomdb/database.py
@@ -529,13 +529,14 @@ class AtomDB(ABC):
     def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Tuple[int, int]:
         """
         Count the total number of atoms in the database.
+        If the optional parameter 'precision' is set to 'precise' returns the node count and link count (slow).
 
         Args:
             parameters (Optional[Dict[str, Any]]): Dict containing the following key 'precision' - sets the count
                 precision as 'precise' or 'fast'. Default value for 'precision' is 'fast'. Defaults to None.
 
         Returns:
-            Tuple[int, int]: (node_count, link_count).
+            Tuple[int, int]: (node_count or atom_count, link_count).
         """
         ...  # pragma no cover
 

--- a/hyperon_das_atomdb/database.py
+++ b/hyperon_das_atomdb/database.py
@@ -526,17 +526,20 @@ class AtomDB(ABC):
         ...  # pragma no cover
 
     @abstractmethod
-    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Tuple[int, int]:
+    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Dict[str, int]:
         """
         Count the total number of atoms in the database.
-        If the optional parameter 'precision' is set to 'precise' returns the node count and link count (slow).
+        If the optional parameter 'precise' is set to True returns the node count and link count (slow).
 
         Args:
-            parameters (Optional[Dict[str, Any]]): Dict containing the following key 'precision' - sets the count
-                precision as 'precise' or 'fast'. Default value for 'precision' is 'fast'. Defaults to None.
+            parameters (Optional[Dict[str, Any]]): Dict containing the following key 'precise' - sets the count
+                precision as 'precise' if True or 'fast' if False. Default value for 'precise' is False.
+                Defaults to None.
 
         Returns:
-            Tuple[int, int]: (node_count or atom_count, link_count).
+            Dict[str, int]: A dict containing str keys and integers, where the key 'node_count' has an integer which is
+                the count of node atoms, the key 'link_count' is the count of link atoms and 'atom_count' is the count
+                of all atoms.
         """
         ...  # pragma no cover
 

--- a/tests/integration/adapters/test_redis_mongo.py
+++ b/tests/integration/adapters/test_redis_mongo.py
@@ -98,11 +98,14 @@ class TestRedisMongo:
     def test_redis_retrieve(self, _cleanup, _db: RedisMongoDB):
         db = _db
         self._add_atoms(db)
-        assert db.count_atoms() == (0, 0)
+        assert db.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
         db.commit()
-        assert db.count_atoms() == (40, 0)
-        assert db.count_atoms({'precision': 'precise'}) == (14, 26)
-
+        assert db.count_atoms() == {'atom_count': 40, 'node_count': 0, 'link_count': 0}
+        assert db.count_atoms({'precise': True}) == {
+            'atom_count': 40,
+            'node_count': 14,
+            'link_count': 26,
+        }
         assert db._retrieve_name(human) == "human"
 
         _, links = db._retrieve_incoming_set(mammal)
@@ -219,16 +222,16 @@ class TestRedisMongo:
         db = _db
         self._add_atoms(db)
         db.commit()
-        assert db.count_atoms() == (40, 0)
+        assert db.count_atoms() == {'atom_count': 40, 'node_count': 0, 'link_count': 0}
         self._check_basic_patterns(db)
 
     def test_commit(self, _cleanup, _db: RedisMongoDB):
         db = _db
-        assert db.count_atoms() == (0, 0)
+        assert db.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
         self._add_atoms(db)
-        assert db.count_atoms() == (0, 0)
+        assert db.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
         db.commit()
-        assert db.count_atoms() == (40, 0)
+        assert db.count_atoms() == {'atom_count': 40, 'node_count': 0, 'link_count': 0}
         assert sorted(
             [
                 answer[1]
@@ -255,7 +258,11 @@ class TestRedisMongo:
             }
         )
         db.commit()
-        assert db.count_atoms({'precision': 'precise'}) == (15, 27)
+        assert db.count_atoms({'precise': True}) == {
+            'atom_count': 42,
+            'node_count': 15,
+            'link_count': 27,
+        }
         link_pos = db.get_atom(inheritance[human][mammal])
         assert link_pos["named_type"] == "Inheritance"
         assert link_pos["targets"] == [human, mammal]
@@ -280,7 +287,7 @@ class TestRedisMongo:
         self._add_atoms(db)
         db.commit()
         db.reindex()
-        assert db.count_atoms() == (40, 0)
+        assert db.count_atoms() == {'atom_count': 40, 'node_count': 0, 'link_count': 0}
         self._check_basic_patterns(db)
         _db_down()
 
@@ -331,7 +338,11 @@ class TestRedisMongo:
             db.commit()
 
         def _check_asserts():
-            assert db.count_atoms({'precision': 'precise'}) == (3, 2)
+            assert db.count_atoms({'precise': True}) == {
+                'atom_count': 5,
+                'node_count': 3,
+                'link_count': 2,
+            }
             assert db._retrieve_name(cat_handle) == 'cat'
             assert db._retrieve_name(dog_handle) == 'dog'
             assert db._retrieve_name(mammal_handle) == 'mammal'
@@ -424,7 +435,7 @@ class TestRedisMongo:
             ]
 
         def _check_asserts_2():
-            assert db.count_atoms() == (3, 0)
+            assert db.count_atoms() == {'atom_count': 3, 'node_count': 0, 'link_count': 0}
             assert db._retrieve_name(cat_handle) == 'cat'
             assert db._retrieve_name(dog_handle) == 'dog'
             assert db._retrieve_name(mammal_handle) == 'mammal'
@@ -449,7 +460,7 @@ class TestRedisMongo:
             assert db._retrieve_pattern('9fb71ffef74a1a98eb0bfce7aa3d54e3')[1] == []
 
         def _check_asserts_3():
-            assert db.count_atoms() == (2, 0)
+            assert db.count_atoms() == {'atom_count': 2, 'node_count': 0, 'link_count': 0}
             assert db._retrieve_name(cat_handle) == 'cat'
             assert db._retrieve_name(dog_handle) == 'dog'
             assert db._retrieve_name(mammal_handle) is None
@@ -474,7 +485,11 @@ class TestRedisMongo:
             assert db._retrieve_pattern('9fb71ffef74a1a98eb0bfce7aa3d54e3')[1] == []
 
         def _check_asserts_4():
-            assert db.count_atoms({'precision': 'precise'}) == (2, 1)
+            assert db.count_atoms({'precise': True}) == {
+                'atom_count': 3,
+                'node_count': 2,
+                'link_count': 1,
+            }
             assert db._retrieve_name(cat_handle) is None
             assert db._retrieve_name(dog_handle) == 'dog'
             assert db._retrieve_name(mammal_handle) == 'mammal'
@@ -521,7 +536,11 @@ class TestRedisMongo:
             assert db._retrieve_pattern('9fb71ffef74a1a98eb0bfce7aa3d54e3')[1] == []
 
         def _check_asserts_5():
-            assert db.count_atoms({'precision': 'precise'}) == (2, 1)
+            assert db.count_atoms({'precise': True}) == {
+                'atom_count': 3,
+                'node_count': 2,
+                'link_count': 1,
+            }
             assert db._retrieve_name(cat_handle) == 'cat'
             assert db._retrieve_name(dog_handle) is None
             assert db._retrieve_name(mammal_handle) == 'mammal'
@@ -579,7 +598,7 @@ class TestRedisMongo:
             'Inheritance', [dog_handle, mammal_handle]
         )
 
-        assert db.count_atoms() == (0, 0)
+        assert db.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
 
         _add_all_links()
         _check_asserts()
@@ -1109,7 +1128,7 @@ class TestRedisMongo:
 
     def test_bulk_insert(self, _cleanup, _db: RedisMongoDB):
         db = _db
-        assert db.count_atoms() == (0, 0)
+        assert db.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
 
         documents = [
             {
@@ -1138,7 +1157,7 @@ class TestRedisMongo:
 
         db.bulk_insert(documents)
 
-        assert db.count_atoms() == (3, 0)
+        assert db.count_atoms() == {'atom_count': 3, 'node_count': 0, 'link_count': 0}
         assert db.get_matched_links('Similarity', ['node1', 'node2']) == [
             db.link_handle('Similarity', ['node1', 'node2'])
         ]
@@ -1193,7 +1212,7 @@ class TestRedisMongo:
 
     def test_commit_with_buffer(self, _cleanup, _db: RedisMongoDB):
         db = _db
-        assert db.count_atoms() == (0, 0)
+        assert db.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
         buffer = [
             {
                 '_id': '26d35e45817f4270f2b7cff971b04138',
@@ -1223,7 +1242,11 @@ class TestRedisMongo:
             },
         ]
         db.commit(buffer=buffer)
-        assert db.count_atoms({'precision': 'precise'}) == (2, 1)
+        assert db.count_atoms({'precise': True}) == {
+            'atom_count': 3,
+            'node_count': 2,
+            'link_count': 1,
+        }
         assert db.get_atom('26d35e45817f4270f2b7cff971b04138')['name'] == 'dog'
         assert db.get_atom('b7db6a9ed2191eb77ee54479570db9a4')['name'] == 'cat'
         assert db.get_atom('3dab102938606f4549d68405ec9f4f61')['targets'] == [

--- a/tests/integration/adapters/test_redis_mongo.py
+++ b/tests/integration/adapters/test_redis_mongo.py
@@ -100,7 +100,8 @@ class TestRedisMongo:
         self._add_atoms(db)
         assert db.count_atoms() == (0, 0)
         db.commit()
-        assert db.count_atoms() == (14, 26)
+        assert db.count_atoms() == (40, 0)
+        assert db.count_atoms({'precision': 'precise'}) == (14, 26)
 
         assert db._retrieve_name(human) == "human"
 
@@ -218,7 +219,7 @@ class TestRedisMongo:
         db = _db
         self._add_atoms(db)
         db.commit()
-        assert db.count_atoms() == (14, 26)
+        assert db.count_atoms() == (40, 0)
         self._check_basic_patterns(db)
 
     def test_commit(self, _cleanup, _db: RedisMongoDB):
@@ -227,7 +228,7 @@ class TestRedisMongo:
         self._add_atoms(db)
         assert db.count_atoms() == (0, 0)
         db.commit()
-        assert db.count_atoms() == (14, 26)
+        assert db.count_atoms() == (40, 0)
         assert sorted(
             [
                 answer[1]
@@ -254,7 +255,7 @@ class TestRedisMongo:
             }
         )
         db.commit()
-        assert db.count_atoms() == (15, 27)
+        assert db.count_atoms({'precision': 'precise'}) == (15, 27)
         link_pos = db.get_atom(inheritance[human][mammal])
         assert link_pos["named_type"] == "Inheritance"
         assert link_pos["targets"] == [human, mammal]
@@ -279,7 +280,7 @@ class TestRedisMongo:
         self._add_atoms(db)
         db.commit()
         db.reindex()
-        assert db.count_atoms() == (14, 26)
+        assert db.count_atoms() == (40, 0)
         self._check_basic_patterns(db)
         _db_down()
 
@@ -330,7 +331,7 @@ class TestRedisMongo:
             db.commit()
 
         def _check_asserts():
-            assert db.count_atoms() == (3, 2)
+            assert db.count_atoms({'precision': 'precise'}) == (3, 2)
             assert db._retrieve_name(cat_handle) == 'cat'
             assert db._retrieve_name(dog_handle) == 'dog'
             assert db._retrieve_name(mammal_handle) == 'mammal'
@@ -473,7 +474,7 @@ class TestRedisMongo:
             assert db._retrieve_pattern('9fb71ffef74a1a98eb0bfce7aa3d54e3')[1] == []
 
         def _check_asserts_4():
-            assert db.count_atoms() == (2, 1)
+            assert db.count_atoms({'precision': 'precise'}) == (2, 1)
             assert db._retrieve_name(cat_handle) is None
             assert db._retrieve_name(dog_handle) == 'dog'
             assert db._retrieve_name(mammal_handle) == 'mammal'
@@ -520,7 +521,7 @@ class TestRedisMongo:
             assert db._retrieve_pattern('9fb71ffef74a1a98eb0bfce7aa3d54e3')[1] == []
 
         def _check_asserts_5():
-            assert db.count_atoms() == (2, 1)
+            assert db.count_atoms({'precision': 'precise'}) == (2, 1)
             assert db._retrieve_name(cat_handle) == 'cat'
             assert db._retrieve_name(dog_handle) is None
             assert db._retrieve_name(mammal_handle) == 'mammal'
@@ -1137,7 +1138,7 @@ class TestRedisMongo:
 
         db.bulk_insert(documents)
 
-        assert db.count_atoms() == (2, 1)
+        assert db.count_atoms() == (3, 0)
         assert db.get_matched_links('Similarity', ['node1', 'node2']) == [
             db.link_handle('Similarity', ['node1', 'node2'])
         ]
@@ -1222,7 +1223,7 @@ class TestRedisMongo:
             },
         ]
         db.commit(buffer=buffer)
-        assert db.count_atoms() == (2, 1)
+        assert db.count_atoms({'precision': 'precise'}) == (2, 1)
         assert db.get_atom('26d35e45817f4270f2b7cff971b04138')['name'] == 'dog'
         assert db.get_atom('b7db6a9ed2191eb77ee54479570db9a4')['name'] == 'cat'
         assert db.get_atom('3dab102938606f4549d68405ec9f4f61')['targets'] == [

--- a/tests/integration/adapters/test_redis_mongo.py
+++ b/tests/integration/adapters/test_redis_mongo.py
@@ -98,9 +98,9 @@ class TestRedisMongo:
     def test_redis_retrieve(self, _cleanup, _db: RedisMongoDB):
         db = _db
         self._add_atoms(db)
-        assert db.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
+        assert db.count_atoms() == {'atom_count': 0}
         db.commit()
-        assert db.count_atoms() == {'atom_count': 40, 'node_count': 0, 'link_count': 0}
+        assert db.count_atoms() == {'atom_count': 40}
         assert db.count_atoms({'precise': True}) == {
             'atom_count': 40,
             'node_count': 14,
@@ -222,16 +222,16 @@ class TestRedisMongo:
         db = _db
         self._add_atoms(db)
         db.commit()
-        assert db.count_atoms() == {'atom_count': 40, 'node_count': 0, 'link_count': 0}
+        assert db.count_atoms() == {'atom_count': 40}
         self._check_basic_patterns(db)
 
     def test_commit(self, _cleanup, _db: RedisMongoDB):
         db = _db
-        assert db.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
+        assert db.count_atoms() == {'atom_count': 0}
         self._add_atoms(db)
-        assert db.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
+        assert db.count_atoms() == {'atom_count': 0}
         db.commit()
-        assert db.count_atoms() == {'atom_count': 40, 'node_count': 0, 'link_count': 0}
+        assert db.count_atoms() == {'atom_count': 40}
         assert sorted(
             [
                 answer[1]
@@ -287,7 +287,7 @@ class TestRedisMongo:
         self._add_atoms(db)
         db.commit()
         db.reindex()
-        assert db.count_atoms() == {'atom_count': 40, 'node_count': 0, 'link_count': 0}
+        assert db.count_atoms() == {'atom_count': 40}
         self._check_basic_patterns(db)
         _db_down()
 
@@ -435,7 +435,7 @@ class TestRedisMongo:
             ]
 
         def _check_asserts_2():
-            assert db.count_atoms() == {'atom_count': 3, 'node_count': 0, 'link_count': 0}
+            assert db.count_atoms() == {'atom_count': 3}
             assert db._retrieve_name(cat_handle) == 'cat'
             assert db._retrieve_name(dog_handle) == 'dog'
             assert db._retrieve_name(mammal_handle) == 'mammal'
@@ -460,7 +460,7 @@ class TestRedisMongo:
             assert db._retrieve_pattern('9fb71ffef74a1a98eb0bfce7aa3d54e3')[1] == []
 
         def _check_asserts_3():
-            assert db.count_atoms() == {'atom_count': 2, 'node_count': 0, 'link_count': 0}
+            assert db.count_atoms() == {'atom_count': 2}
             assert db._retrieve_name(cat_handle) == 'cat'
             assert db._retrieve_name(dog_handle) == 'dog'
             assert db._retrieve_name(mammal_handle) is None
@@ -598,7 +598,7 @@ class TestRedisMongo:
             'Inheritance', [dog_handle, mammal_handle]
         )
 
-        assert db.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
+        assert db.count_atoms() == {'atom_count': 0}
 
         _add_all_links()
         _check_asserts()
@@ -1128,7 +1128,7 @@ class TestRedisMongo:
 
     def test_bulk_insert(self, _cleanup, _db: RedisMongoDB):
         db = _db
-        assert db.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
+        assert db.count_atoms() == {'atom_count': 0}
 
         documents = [
             {
@@ -1157,7 +1157,7 @@ class TestRedisMongo:
 
         db.bulk_insert(documents)
 
-        assert db.count_atoms() == {'atom_count': 3, 'node_count': 0, 'link_count': 0}
+        assert db.count_atoms() == {'atom_count': 3}
         assert db.get_matched_links('Similarity', ['node1', 'node2']) == [
             db.link_handle('Similarity', ['node1', 'node2'])
         ]
@@ -1212,7 +1212,7 @@ class TestRedisMongo:
 
     def test_commit_with_buffer(self, _cleanup, _db: RedisMongoDB):
         db = _db
-        assert db.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
+        assert db.count_atoms() == {'atom_count': 0}
         buffer = [
             {
                 '_id': '26d35e45817f4270f2b7cff971b04138',

--- a/tests/unit/adapters/test_ram_only.py
+++ b/tests/unit/adapters/test_ram_only.py
@@ -748,7 +748,7 @@ class TestInMemoryDB:
 
         db = InMemoryDB()
 
-        assert db.count_atoms() == (0, 0)
+        assert db.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
 
         db.add_link(
             {
@@ -769,7 +769,7 @@ class TestInMemoryDB:
             }
         )
 
-        assert db.count_atoms() == (3, 2)
+        assert db.count_atoms() == {'atom_count': 5, 'node_count': 3, 'link_count': 2}
         assert db.db.incoming_set == {
             dog_handle: {inheritance_dog_mammal_handle},
             cat_handle: {inheritance_cat_mammal_handle},
@@ -828,7 +828,7 @@ class TestInMemoryDB:
 
         db.delete_atom(inheritance_cat_mammal_handle)
         db.delete_atom(inheritance_dog_mammal_handle)
-        assert db.count_atoms() == (3, 0)
+        assert db.count_atoms() == {'atom_count': 3, 'node_count': 3, 'link_count': 0}
         assert db.db.incoming_set == {
             dog_handle: set(),
             cat_handle: set(),
@@ -872,7 +872,7 @@ class TestInMemoryDB:
         )
 
         db.delete_atom(mammal_handle)
-        assert db.count_atoms() == (2, 0)
+        assert db.count_atoms() == {'atom_count': 2, 'node_count': 2, 'link_count': 0}
         assert db.db.incoming_set == {
             dog_handle: set(),
             cat_handle: set(),
@@ -915,7 +915,7 @@ class TestInMemoryDB:
         )
 
         db.delete_atom(cat_handle)
-        assert db.count_atoms() == (2, 1)
+        assert db.count_atoms() == {'atom_count': 3, 'node_count': 2, 'link_count': 1}
         assert db.db.incoming_set == {
             dog_handle: {inheritance_dog_mammal_handle},
             mammal_handle: {inheritance_dog_mammal_handle},
@@ -967,7 +967,7 @@ class TestInMemoryDB:
         )
 
         db.delete_atom(dog_handle)
-        assert db.count_atoms() == (2, 1)
+        assert db.count_atoms() == {'atom_count': 3, 'node_count': 2, 'link_count': 1}
         assert db.db.incoming_set == {
             cat_handle: {inheritance_cat_mammal_handle},
             mammal_handle: {inheritance_cat_mammal_handle},
@@ -1033,7 +1033,7 @@ class TestInMemoryDB:
         )
 
         db.delete_atom(inheritance_cat_mammal_handle)
-        assert db.count_atoms() == (3, 0)
+        assert db.count_atoms() == {'atom_count': 3, 'node_count': 3, 'link_count': 0}
         assert db.db.incoming_set == {
             dog_handle: set(),
             cat_handle: set(),
@@ -1151,7 +1151,7 @@ class TestInMemoryDB:
     def test_bulk_insert(self):
         db = InMemoryDB()
 
-        assert db.count_atoms() == (0, 0)
+        assert db.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
 
         documents = [
             {
@@ -1180,7 +1180,7 @@ class TestInMemoryDB:
 
         db.bulk_insert(documents)
 
-        assert db.count_atoms() == (2, 1)
+        assert db.count_atoms() == {'atom_count': 3, 'node_count': 2, 'link_count': 1}
 
     def test_retrieve_all_atoms(self, database: InMemoryDB):
         expected = list(database.db.node.items()) + list(database.db.link.items())

--- a/tests/unit/adapters/test_redis_mongo_db.py
+++ b/tests/unit/adapters/test_redis_mongo_db.py
@@ -411,10 +411,10 @@ class TestRedisMongoDB:
 
     def test_atom_count_fast(self, database: RedisMongoDB):
         response = database.count_atoms()
-        assert response == {'atom_count': 42, 'node_count': 0, 'link_count': 0}
+        assert response == {'atom_count': 42}
 
     def test_add_node(self, database: RedisMongoDB):
-        assert {'atom_count': 42, 'node_count': 0, 'link_count': 0} == database.count_atoms()
+        assert {'atom_count': 42} == database.count_atoms()
         all_nodes_before = database.get_all_nodes('Concept')
         database.add_node(
             {
@@ -439,7 +439,7 @@ class TestRedisMongoDB:
         assert new_node['name'] == 'lion'
 
     def test_add_link(self, database: RedisMongoDB):
-        assert {'atom_count': 42, 'node_count': 0, 'link_count': 0} == database.count_atoms()
+        assert {'atom_count': 42} == database.count_atoms()
 
         all_nodes_before = database.get_all_nodes('Concept')
         _, similarity = database.get_all_links('Similarity')

--- a/tests/unit/adapters/test_redis_mongo_db.py
+++ b/tests/unit/adapters/test_redis_mongo_db.py
@@ -406,12 +406,17 @@ class TestRedisMongoDB:
         assert 'Similarity' == resp_link
 
     def test_atom_count(self, database: RedisMongoDB):
-        node_count, link_count = database.count_atoms()
+        node_count, link_count = database.count_atoms({'precision': 'precise'})
         assert node_count == 14
         assert link_count == 28
 
+    def test_atom_count_fast(self, database: RedisMongoDB):
+        node_count, link_count = database.count_atoms()
+        assert node_count == 14 + 28
+        assert link_count == 0
+
     def test_add_node(self, database: RedisMongoDB):
-        assert (14, 28) == database.count_atoms()
+        assert (42, 0) == database.count_atoms()
         all_nodes_before = database.get_all_nodes('Concept')
         database.add_node(
             {
@@ -423,7 +428,7 @@ class TestRedisMongoDB:
         all_nodes_after = database.get_all_nodes('Concept')
         assert len(all_nodes_before) == 14
         assert len(all_nodes_after) == 15
-        assert (15, 28) == database.count_atoms()
+        assert (15, 28) == database.count_atoms({'precision': 'precise'})
         new_node_handle = database.get_node_handle('Concept', 'lion')
         assert new_node_handle == ExpressionHasher.terminal_hash('Concept', 'lion')
         assert new_node_handle not in all_nodes_before
@@ -435,7 +440,7 @@ class TestRedisMongoDB:
         database.count_atoms()
 
     def test_add_link(self, database: RedisMongoDB):
-        assert (14, 28) == database.count_atoms()
+        assert (42, 0) == database.count_atoms()
 
         all_nodes_before = database.get_all_nodes('Concept')
         _, similarity = database.get_all_links('Similarity')
@@ -461,7 +466,7 @@ class TestRedisMongoDB:
         assert len(all_nodes_after) == 16
         assert len(all_links_before) == 28
         assert len(all_links_after) == 29
-        assert (16, 29) == database.count_atoms()
+        assert (16, 29) == database.count_atoms({'precision': 'precise'})
 
         new_node_handle = database.get_node_handle('Concept', 'lion')
         assert new_node_handle == ExpressionHasher.terminal_hash('Concept', 'lion')

--- a/tests/unit/adapters/test_redis_mongo_db.py
+++ b/tests/unit/adapters/test_redis_mongo_db.py
@@ -406,17 +406,15 @@ class TestRedisMongoDB:
         assert 'Similarity' == resp_link
 
     def test_atom_count(self, database: RedisMongoDB):
-        node_count, link_count = database.count_atoms({'precision': 'precise'})
-        assert node_count == 14
-        assert link_count == 28
+        response = database.count_atoms({'precise': True})
+        assert response == {'atom_count': 42, 'node_count': 14, 'link_count': 28}
 
     def test_atom_count_fast(self, database: RedisMongoDB):
-        node_count, link_count = database.count_atoms()
-        assert node_count == 14 + 28
-        assert link_count == 0
+        response = database.count_atoms()
+        assert response == {'atom_count': 42, 'node_count': 0, 'link_count': 0}
 
     def test_add_node(self, database: RedisMongoDB):
-        assert (42, 0) == database.count_atoms()
+        assert {'atom_count': 42, 'node_count': 0, 'link_count': 0} == database.count_atoms()
         all_nodes_before = database.get_all_nodes('Concept')
         database.add_node(
             {
@@ -428,7 +426,9 @@ class TestRedisMongoDB:
         all_nodes_after = database.get_all_nodes('Concept')
         assert len(all_nodes_before) == 14
         assert len(all_nodes_after) == 15
-        assert (15, 28) == database.count_atoms({'precision': 'precise'})
+        assert {'atom_count': 43, 'node_count': 15, 'link_count': 28} == database.count_atoms(
+            {'precise': True}
+        )
         new_node_handle = database.get_node_handle('Concept', 'lion')
         assert new_node_handle == ExpressionHasher.terminal_hash('Concept', 'lion')
         assert new_node_handle not in all_nodes_before
@@ -437,10 +437,9 @@ class TestRedisMongoDB:
         assert new_node['handle'] == new_node_handle
         assert new_node['named_type'] == 'Concept'
         assert new_node['name'] == 'lion'
-        database.count_atoms()
 
     def test_add_link(self, database: RedisMongoDB):
-        assert (42, 0) == database.count_atoms()
+        assert {'atom_count': 42, 'node_count': 0, 'link_count': 0} == database.count_atoms()
 
         all_nodes_before = database.get_all_nodes('Concept')
         _, similarity = database.get_all_links('Similarity')
@@ -466,7 +465,9 @@ class TestRedisMongoDB:
         assert len(all_nodes_after) == 16
         assert len(all_links_before) == 28
         assert len(all_links_after) == 29
-        assert (16, 29) == database.count_atoms({'precision': 'precise'})
+        assert {'atom_count': 45, 'node_count': 16, 'link_count': 29} == database.count_atoms(
+            {'precise': True}
+        )
 
         new_node_handle = database.get_node_handle('Concept', 'lion')
         assert new_node_handle == ExpressionHasher.terminal_hash('Concept', 'lion')


### PR DESCRIPTION
Added new parameter to count_atoms, the behavior was changed for count_atoms:
- Old:
  - Returns the total number of nodes and links (slow)
    - eg: (16, 24) 
- New
  - Returns the total number of atoms (fast)
    - eg: (40, 0)  