### PR TITLE
[#169] adding pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,222 @@
+[MASTER]
+
+py-version=3.10
+
+
+[MESSAGES CONTROL]
+
+disable=all
+enable=
+  abstract-method,
+  anomalous-backslash-in-string,
+  anomalous-unicode-escape-in-string,
+  astroid-error,
+  attribute-defined-outside-init,
+  bad-classmethod-argument,
+  bad-except-order,
+  bad-exception-context,
+  bad-format-character,
+  bad-format-string,
+  bad-format-string-key,
+  bad-mcs-classmethod-argument,
+  bad-mcs-method-argument,
+  bad-open-mode,
+  bad-option-value,
+  bad-reversed-sequence,
+  bad-staticmethod-argument,
+  bad-str-strip-call,
+  bad-string-format-type,
+  bad-super-call,
+  bare-except,
+  blacklisted-name,
+  broad-except,
+  c-extension-no-member,
+  cell-var-from-loop,
+  chained-comparison,
+  class-variable-slots-conflict,
+  comparison-with-itself,
+  consider-iterating-dictionary,
+  consider-merging-isinstance,
+  consider-swap-variables,
+  consider-using-dict-comprehension,
+  consider-using-enumerate,
+  consider-using-get,
+  consider-using-in,
+  consider-using-join,
+  consider-using-set-comprehension,
+  consider-using-sys-exit,
+  consider-using-ternary,
+  continue-in-finally,
+  dangerous-default-value,
+  deprecated-method,
+  deprecated-module,
+  dict-iter-missing-items,
+  duplicate-except,
+  duplicate-key,
+  duplicate-string-formatting-argument,
+  empty-docstring,
+  eval-used,
+  exec-used,
+  expression-not-assigned,
+  fatal,
+  format-combined-specification,
+  format-needs-mapping,
+  global-at-module-level,
+  global-statement,
+  global-variable-not-assigned,
+  import-outside-toplevel,
+  import-self,
+  inconsistent-return-statements,
+  init-is-generator,
+  invalid-all-object,
+  invalid-characters-in-docstring,
+  invalid-envvar-default,
+  invalid-format-index,
+  invalid-length-returned,
+  invalid-name,
+  invalid-slots-object,
+  literal-comparison,
+  logging-format-interpolation,
+  logging-format-truncated,
+  logging-not-lazy,
+  logging-too-few-args,
+  logging-too-many-args,
+  logging-unsupported-format,
+  lost-exception,
+  method-check-failed,
+  misplaced-bare-raise,
+  misplaced-future,
+  missing-format-argument-key,
+  missing-format-attribute,
+  missing-format-string-key,
+  missing-kwoa,
+  missing-parentheses-for-call-in-test,
+  mixed-format-string,
+  multiple-imports,
+  no-classmethod-decorator,
+  no-else-continue,
+  no-self-argument,
+  non-iterator-returned,
+  non-parent-init-called,
+  nonlocal-and-global,
+  nonlocal-without-binding,
+  notimplemented-raised,
+  parse-error,
+  pointless-statement,
+  pointless-string-statement,
+  possibly-unused-variable,
+  preferred-module,
+  protected-access,
+  raising-format-tuple,
+  redeclared-assigned-name,
+  redefined-argument-from-local,
+  redefined-builtin,
+  redefined-outer-name,
+  redundant-unittest-assert,
+  reimported,
+  relative-beyond-top-level,
+  return-arg-in-generator,
+  return-in-init,
+  self-assigning-variable,
+  self-cls-assignment,
+  shallow-copy-environ,
+  simplifiable-if-expression,
+  simplifiable-if-statement,
+  simplify-boolean-expression,
+  single-string-used-for-slots,
+  singleton-comparison,
+  subprocess-popen-preexec-fn,
+  subprocess-run-check,
+  super-init-not-called,
+  too-few-format-args,
+  too-many-format-args,
+  too-many-nested-blocks,
+  too-many-star-expressions,
+  trailing-comma-tuple,
+  truncated-format-string,
+  try-except-raise,
+  undefined-all-variable,
+  undefined-loop-variable,
+  undefined-variable,
+  unexpected-line-ending-format,
+  ungrouped-imports,
+  unidiomatic-typecheck,
+  unnecessary-comprehension,
+  unnecessary-pass,
+  unneeded-not,
+  unreachable,
+  unrecognized-inline-option,
+  unused-format-string-argument,
+  unused-format-string-key,
+  unused-import,
+  unused-variable,
+  unused-wildcard-import,
+  used-before-assignment,
+  used-prior-global-declaration,
+  useless-else-on-loop,
+  useless-object-inheritance,
+  using-constant-test,
+  wildcard-import,
+  wrong-exception-operation,
+  wrong-import-position,
+  wrong-spelling-in-comment,
+  wrong-spelling-in-docstring,
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized and json.
+output-format=parseable,colorized
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+
+[SCORE]
+score=no
+
+
+[CLASSES]
+valid-classmethod-first-arg=cls
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[EXCEPTIONS]
+overgeneral-exceptions=builtins.Exception
+
+
+[BASIC]
+good-names=i,j,k,ex,Run,_,logger,T
+variable-rgx=(([a-z][a-z0-9_]{0,})|(_[a-z0-9_]*))$
+argument-rgx=(F|([a-z][a-z0-9_]{0,})|(_[a-z0-9_]*))$
+attr-rgx=(([a-z][a-z0-9_]{0,})|(_[a-z0-9_]*))$
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+bad-names=toto,tutu,tata
+
+
+[VARIABLES]
+
+dummy-variables-rgx=(_+[a-zA-Z0-9_]*?$)|dummy
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ black:
 flake8:
 	@flake8 ./hyperon_das_atomdb ./tests --show-source --extend-ignore E501
 
+pylint:
+	@pylint ./hyperon_das_atomdb --rcfile=.pylintrc
+
 lint: isort black flake8
 
 unit-tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ setuptools = "^70.2.0"
 
 [tool.poetry.group.dev.dependencies]
 flake8 = "^6.1.0"
+pylint = "^3.2.6"
 isort = "^5.12.0"
 black = "^23.7.0"
 pytest = "^7.4.2"


### PR DESCRIPTION
Closes #169 

Adds a new target to `Makefile`, named `pylint`.
For now, `make pylint` must be executed manually. Once all code base is passing green through `pylint`, it must be added to the CI pipeline as well as to the `Makefile`'s `pre-commit` target.