### PR TITLE
[#161] refactoring `ram_only.py`

### DIFF
--- a/hyperon_das_atomdb/adapters/ram_only.py
+++ b/hyperon_das_atomdb/adapters/ram_only.py
@@ -1,6 +1,17 @@
+"""
+This module provides an in-memory implementation of the AtomDB interface using hashtables (dict).
+
+The InMemoryDB class offers methods for managing nodes and links, including adding, deleting,
+and retrieving them. It also supports indexing and pattern matching for efficient querying.
+
+Classes:
+    Database: A dataclass representing the structure of the in-memory database.
+    InMemoryDB: A concrete implementation of the AtomDB interface using hashtables.
+"""
+
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import Any, Iterable
 
 from hyperon_das_atomdb.database import (
     UNORDERED_LINK_TYPES,
@@ -18,22 +29,39 @@ from hyperon_das_atomdb.utils.patterns import build_pattern_keys
 
 @dataclass
 class Database:
-    atom_type: Dict[str, Any]
-    node: Dict[str, Any]
-    link: Dict[str, Any]
-    outgoing_set: Dict[str, Any]
-    incoming_set: Dict[str, Any]
-    patterns: Dict[str, Set[Tuple]]
-    templates: Dict[str, Set[Tuple]]
+    """Dataclass representing the structure of the in-memory database"""
+
+    atom_type: dict[str, Any]
+    node: dict[str, Any]
+    link: dict[str, Any]
+    outgoing_set: dict[str, Any]
+    incoming_set: dict[str, set[str]]
+    patterns: dict[str, set[tuple[str, tuple[str, ...]]]]
+    templates: dict[str, set[tuple[str, tuple[str, ...]]]]
 
 
 class InMemoryDB(AtomDB):
     """A concrete implementation using hashtable (dict)"""
 
     def __repr__(self) -> str:
+        """
+        Return a string representation of the InMemoryDB instance.
+
+        This method is intended to provide a human-readable representation of the
+        InMemoryDB instance, which can be useful for debugging and logging purposes.
+
+        Returns:
+            str: A string representing the InMemoryDB instance.
+        """
         return "<Atom database InMemory>"  # pragma no cover
 
-    def __init__(self, database_name: str = "das") -> None:
+    def __init__(self, database_name: str = "das"):
+        """
+        Initialize an InMemoryDB instance.
+
+        Args:
+            database_name (str): The name of the database. Defaults to "das".
+        """
         self.database_name = database_name
         self.named_type_table = {}  # keyed by named type hash
         self.all_named_types = set()
@@ -47,32 +75,73 @@ class InMemoryDB(AtomDB):
             templates={},
         )
 
-    def _get_link(self, handle: str) -> Optional[Dict[str, Any]]:
+    def _get_link(self, handle: str) -> dict[str, Any] | None:
+        """
+        Retrieve a link from the database by its handle.
+
+        Args:
+            handle (str): The handle of the link to retrieve.
+
+        Returns:
+            dict[str, Any] | None: The link document if found, otherwise None.
+        """
         link = self.db.link.get(handle)
         if link is not None:
             return link
         return None
 
-    def _get_and_delete_link(self, link_handle: str) -> Optional[Dict[str, Any]]:
-        link_document = self.db.link.pop(link_handle, None)
-        if link_document:
-            return link_document
+    def _get_and_delete_link(self, link_handle: str) -> dict[str, Any] | None:
+        """
+        Retrieve and delete a link from the database by its handle.
 
-    def _build_named_type_hash_template(
-        self, template: Union[str, List[Any]]
-    ) -> Union[str, List[Any]]:
+        Args:
+            link_handle (str): The handle of the link to retrieve and delete.
+
+        Returns:
+            dict[str, Any] | None: The link document if found and deleted, otherwise None.
+        """
+        return self.db.link.pop(link_handle, None)
+
+    def _build_named_type_hash_template(self, template: str | list[Any]) -> str | list[Any]:
+        """
+        Build a named type hash template from the given template.
+
+        Args:
+            template (str | list[Any]): The template to build the named type hash from. It can be
+                either a string or a list of elements.
+
+        Returns:
+            str | list[Any]: The named type hash if the template is a string, or a list of named
+                type hashes if the template is a list.
+        """
         if isinstance(template, str):
             return ExpressionHasher.named_type_hash(template)
-        else:
-            return [self._build_named_type_hash_template(element) for element in template]
+        return [self._build_named_type_hash_template(element) for element in template]
 
-    def _build_atom_type_key_hash(self, _name: str) -> str:
+    @staticmethod
+    def _build_atom_type_key_hash(_name: str) -> str:
+        """
+        Build a hash key for the given atom type name.
+
+        Args:
+            _name (str): The name of the atom type.
+
+        Returns:
+            str: The hash key for the atom type.
+        """
         name_hash = ExpressionHasher.named_type_hash(_name)
         type_hash = ExpressionHasher.named_type_hash("Type")
         typedef_mark_hash = ExpressionHasher.named_type_hash(":")
         return ExpressionHasher.expression_hash(typedef_mark_hash, [name_hash, type_hash])
 
-    def _add_atom_type(self, _name: str, _type: Optional[str] = "Type") -> None:
+    def _add_atom_type(self, _name: str, _type: str | None = "Type") -> None:
+        """
+        Add a type atom to the database.
+
+        Args:
+            _name (str): The name of the atom to add.
+            _type (str | None): The type of the atom. Defaults to "Type".
+        """
         if _name in self.all_named_types:
             return
 
@@ -98,17 +167,46 @@ class InMemoryDB(AtomDB):
             self.named_type_table[name_hash] = _name
 
     def _delete_atom_type(self, _name: str) -> None:
+        """
+        Delete an atom type from the database.
+
+        Args:
+            _name (str): The name of the atom type to delete.
+        """
         key = self._build_atom_type_key_hash(_name)
         self.db.atom_type.pop(key, None)
         self.all_named_types.remove(_name)
 
-    def _add_outgoing_set(self, key: str, targets_hash: List[str]) -> None:
+    def _add_outgoing_set(self, key: str, targets_hash: list[str]) -> None:
+        """
+        Add an outgoing set to the database.
+
+        Args:
+            key (str): The key for the outgoing set.
+            targets_hash (list[str]): A list of target hashes to be added to the outgoing set.
+        """
         self.db.outgoing_set[key] = targets_hash
 
-    def _get_and_delete_outgoing_set(self, handle: str) -> Optional[List[str]]:
+    def _get_and_delete_outgoing_set(self, handle: str) -> list[str] | None:
+        """
+        Retrieve and delete an outgoing set from the database by its handle.
+
+        Args:
+            handle (str): The handle of the outgoing set to retrieve and delete.
+
+        Returns:
+            list[str] | None: The outgoing set if found and deleted, otherwise None.
+        """
         return self.db.outgoing_set.pop(handle, None)
 
-    def _add_incoming_set(self, key: str, targets_hash: List[str]) -> None:
+    def _add_incoming_set(self, key: str, targets_hash: list[str]) -> None:
+        """
+        Add an incoming set to the database.
+
+        Args:
+            key (str): The key for the incoming set.
+            targets_hash (list[str]): A list of target hashes to be added to the incoming set.
+        """
         for target_hash in targets_hash:
             incoming_set = self.db.incoming_set.get(target_hash)
             if incoming_set is None:
@@ -116,15 +214,31 @@ class InMemoryDB(AtomDB):
             else:
                 self.db.incoming_set[target_hash].add(key)
 
-    def _delete_incoming_set(self, link_handle: str, atoms_handle: List[str]) -> None:
+    def _delete_incoming_set(self, link_handle: str, atoms_handle: list[str]) -> None:
+        """
+        Delete an incoming set from the database.
+
+        Args:
+            link_handle (str): The handle of the link to delete.
+            atoms_handle (list[str]): A list of atom handles associated with the link.
+        """
         for atom_handle in atoms_handle:
             handles = self.db.incoming_set.get(atom_handle, set())
             if len(handles) > 0:
                 handles.remove(link_handle)
 
     def _add_templates(
-        self, composite_type_hash: str, named_type_hash: str, key: str, targets_hash: List[str]
+        self, composite_type_hash: str, named_type_hash: str, key: str, targets_hash: list[str]
     ) -> None:
+        """
+        Add templates to the database.
+
+        Args:
+            composite_type_hash (str): The hash of the composite type.
+            named_type_hash (str): The hash of the named type.
+            key (str): The key for the template.
+            targets_hash (list[str]): A list of target hashes to be added to the template.
+        """
         template_composite_type_hash = self.db.templates.get(composite_type_hash)
         template_named_type_hash = self.db.templates.get(named_type_hash)
 
@@ -138,7 +252,14 @@ class InMemoryDB(AtomDB):
         else:
             self.db.templates[named_type_hash] = {(key, tuple(targets_hash))}
 
-    def _delete_templates(self, link_document: dict, targets_hash: List[str]) -> None:
+    def _delete_templates(self, link_document: dict, targets_hash: list[str]) -> None:
+        """
+        Delete templates from the database.
+
+        Args:
+            link_document (dict): The document of the link whose templates are to be deleted.
+            targets_hash (list[str]): A list of target hashes associated with the link.
+        """
         template_composite_type = self.db.templates.get(
             link_document[FieldNames.COMPOSITE_TYPE_HASH], set()
         )
@@ -149,7 +270,15 @@ class InMemoryDB(AtomDB):
         if len(template_named_type) > 0:
             template_named_type.remove((link_document[FieldNames.ID_HASH], tuple(targets_hash)))
 
-    def _add_patterns(self, named_type_hash: str, key: str, targets_hash: List[str]) -> None:
+    def _add_patterns(self, named_type_hash: str, key: str, targets_hash: list[str]) -> None:
+        """
+        Add patterns to the database.
+
+        Args:
+            named_type_hash (str): The hash of the named type.
+            key (str): The key for the pattern.
+            targets_hash (list[str]): A list of target hashes to be added to the pattern.
+        """
         pattern_keys = build_pattern_keys([named_type_hash, *targets_hash])
 
         for pattern_key in pattern_keys:
@@ -159,7 +288,14 @@ class InMemoryDB(AtomDB):
             else:
                 self.db.patterns[pattern_key] = {(key, tuple(targets_hash))}
 
-    def _delete_patterns(self, link_document: dict, targets_hash: List[str]) -> None:
+    def _delete_patterns(self, link_document: dict, targets_hash: list[str]) -> None:
+        """
+        Delete patterns from the database.
+
+        Args:
+            link_document (dict): The document of the link whose patterns are to be deleted.
+            targets_hash (list[str]): A list of target hashes associated with the link.
+        """
         pattern_keys = build_pattern_keys([link_document[FieldNames.TYPE_NAME_HASH], *targets_hash])
         for pattern_key in pattern_keys:
             pattern = self.db.patterns.get(pattern_key, set())
@@ -167,11 +303,29 @@ class InMemoryDB(AtomDB):
                 pattern.remove((link_document[FieldNames.ID_HASH], tuple(targets_hash)))
 
     def _delete_link_and_update_index(self, link_handle: str) -> None:
+        """
+        Delete a link from the database and update the index.
+
+        Args:
+            link_handle (str): The handle of the link to delete.
+        """
         link_document = self._get_and_delete_link(link_handle)
         self._update_index(atom=link_document, delete_atom=True)
 
-    def _filter_non_toplevel(self, matches: list) -> List[Tuple]:
-        matches_toplevel_only = []
+    def _filter_non_toplevel(
+        self, matches: list[tuple[str, tuple[str, ...]]]
+    ) -> list[tuple[str, tuple[str, ...]]]:
+        """
+        Filter out non-toplevel matches from the provided list.
+
+        Args:
+            matches (list[tuple[str, tuple[str, ...]]]): A list of matches, where each match is a
+                tuple containing a link handle and a tuple of target handles.
+
+        Returns:
+            list[tuple[str, tuple[str, ...]]]: A list of matches that are toplevel only.
+        """
+        matches_toplevel_only: list[tuple[str, tuple[str, ...]]] = []
         if len(matches) > 0:
             for match in matches:
                 link_handle = match[0]
@@ -180,7 +334,17 @@ class InMemoryDB(AtomDB):
                     matches_toplevel_only.append(match)
         return matches_toplevel_only
 
-    def _build_targets_list(self, link: Dict[str, Any]) -> List[Any]:
+    @staticmethod
+    def _build_targets_list(link: dict[str, Any]) -> list[Any]:
+        """
+        Build a list of target handles from the given link document.
+
+        Args:
+            link (dict[str, Any]): The link document from which to extract target handles.
+
+        Returns:
+            list[Any]: A list of target handles extracted from the link document.
+        """
         targets = []
         count = 0
         while True:
@@ -191,11 +355,29 @@ class InMemoryDB(AtomDB):
             count += 1
         return targets
 
-    def _update_atom_indexes(self, documents: Iterable[Dict[str, any]], **kwargs) -> None:
+    def _update_atom_indexes(self, documents: Iterable[dict[str, any]], **kwargs) -> None:
+        """
+        Update the indexes for the provided documents.
+
+        Args:
+            documents (Iterable[dict[str, any]]): An iterable of documents to update the indexes for.
+            **kwargs: Additional keyword arguments that may be used for updating the indexes.
+        """
         for document in documents:
             self._update_index(document, **kwargs)
 
-    def _update_index(self, atom: Optional[Dict[str, Any]], **kwargs) -> None:
+    def _update_index(self, atom: dict[str, Any] | None, **kwargs) -> None:
+        """
+        Update the index for the provided atom.
+
+        Args:
+            atom (dict[str, Any] | None): The atom document to update the index for.
+            **kwargs: Additional keyword arguments that may be used for updating the index.
+                - delete_atom (bool): If True, the atom will be deleted from the index.
+
+        Raises:
+            AtomDoesNotExist: If the atom does not exist when attempting to delete it.
+        """
         if kwargs.get("delete_atom", False):
             if atom is None:
                 raise AtomDoesNotExist("Nonexistent atom")
@@ -243,15 +425,14 @@ class InMemoryDB(AtomDB):
         node_handle = self.node_handle(node_type, node_name)
         if node_handle in self.db.node:
             return node_handle
-        else:
-            logger().error(
-                f"Failed to retrieve node handle for {node_type}:{node_name}. "
-                "This node may not exist."
-            )
-            raise AtomDoesNotExist(
-                message="Nonexistent atom",
-                details=f"{node_type}:{node_name}",
-            )
+        logger().error(
+            f"Failed to retrieve node handle for {node_type}:{node_name}. "
+            "This node may not exist."
+        )
+        raise AtomDoesNotExist(
+            message="Nonexistent atom",
+            details=f"{node_type}:{node_name}",
+        )
 
     def get_node_name(self, node_handle: str) -> str:
         node = self.db.node.get(node_handle)
@@ -277,7 +458,7 @@ class InMemoryDB(AtomDB):
             )
         return node[FieldNames.TYPE_NAME]
 
-    def get_node_by_name(self, node_type: str, substring: str) -> List[str]:
+    def get_node_by_name(self, node_type: str, substring: str) -> list[str]:
         node_type_hash = ExpressionHasher.named_type_hash(node_type)
         return [
             key
@@ -286,7 +467,7 @@ class InMemoryDB(AtomDB):
             and node_type_hash == value[FieldNames.COMPOSITE_TYPE_HASH]
         ]
 
-    def get_all_nodes(self, node_type: str, names: bool = False) -> List[str]:
+    def get_all_nodes(self, node_type: str, names: bool = False) -> list[str]:
         node_type_hash = ExpressionHasher.named_type_hash(node_type)
 
         if names:
@@ -295,48 +476,44 @@ class InMemoryDB(AtomDB):
                 for value in self.db.node.values()
                 if value[FieldNames.COMPOSITE_TYPE_HASH] == node_type_hash
             ]
-        else:
-            return [
-                key
-                for key, value in self.db.node.items()
-                if value[FieldNames.COMPOSITE_TYPE_HASH] == node_type_hash
-            ]
 
-    def get_all_links(self, link_type: str, **kwargs) -> List[str]:
+        return [
+            key
+            for key, value in self.db.node.items()
+            if value[FieldNames.COMPOSITE_TYPE_HASH] == node_type_hash
+        ]
+
+    def get_all_links(self, link_type: str, **kwargs) -> list[str]:
         answer = []
         for _, link in self.db.link.items():
             if link[FieldNames.TYPE_NAME] == link_type:
                 answer.append(link[FieldNames.ID_HASH])
         return answer
 
-    def get_link_handle(self, link_type: str, target_handles: List[str]) -> str:
+    def get_link_handle(self, link_type: str, target_handles: list[str]) -> str:
         link_handle = self.link_handle(link_type, target_handles)
         if link_handle in self.db.link:
             return link_handle
-        else:
-            logger().error(
-                f"Failed to retrieve link handle for {link_type}:{target_handles}. "
-                f"This link may not exist."
-            )
-            raise AtomDoesNotExist(
-                message="Nonexistent atom",
-                details=f"{link_type}:{target_handles}",
-            )
+        logger().error(
+            f"Failed to retrieve link handle for {link_type}:{target_handles}. "
+            f"This link may not exist."
+        )
+        raise AtomDoesNotExist(
+            message="Nonexistent atom",
+            details=f"{link_type}:{target_handles}",
+        )
 
     def get_link_type(self, link_handle: str) -> str:
         link = self._get_link(link_handle)
         if link is not None:
             return link[FieldNames.TYPE_NAME]
-        else:
-            logger().error(
-                f"Failed to retrieve link type for {link_handle}. This link may not exist."
-            )
-            raise AtomDoesNotExist(
-                message="Nonexistent atom",
-                details=f"link_handle: {link_handle}",
-            )
+        logger().error(f"Failed to retrieve link type for {link_handle}. This link may not exist.")
+        raise AtomDoesNotExist(
+            message="Nonexistent atom",
+            details=f"link_handle: {link_handle}",
+        )
 
-    def get_link_targets(self, link_handle: str) -> List[str]:
+    def get_link_targets(self, link_handle: str) -> list[str]:
         answer = self.db.outgoing_set.get(link_handle)
         if answer is None:
             logger().error(
@@ -352,19 +529,24 @@ class InMemoryDB(AtomDB):
         link = self._get_link(link_handle)
         if link is not None:
             return True
-        else:
-            logger().error(
-                f"Failed to retrieve document for link handle: {link_handle}. "
-                f"The link may not exist."
-            )
-            raise AtomDoesNotExist(
-                message="Nonexistent atom",
-                details=f"link_handle: {link_handle}",
-            )
+        logger().error(
+            f"Failed to retrieve document for link handle: {link_handle}. "
+            f"The link may not exist."
+        )
+        raise AtomDoesNotExist(
+            message="Nonexistent atom",
+            details=f"link_handle: {link_handle}",
+        )
 
     def get_matched_links(
-        self, link_type: str, target_handles: List[str], **kwargs
-    ) -> List[Union[str, Tuple]]:
+        self, link_type: str, target_handles: list[str], **kwargs
+    ) -> (
+        list[str]
+        | list[list[str]]
+        | list[tuple[str, tuple[str, ...]]]
+        | tuple[int, list[str]]
+        | tuple[int, list[list[str]]]  # TODO(angelo): simplify this return type
+    ):
         if link_type != WILDCARD and WILDCARD not in target_handles:
             link_handle = self.get_link_handle(link_type, target_handles)
             return [link_handle]
@@ -393,14 +575,22 @@ class InMemoryDB(AtomDB):
 
         return patterns_matched
 
-    def get_incoming_links(self, atom_handle: str, **kwargs) -> List[IncomingLinksT]:
+    def get_incoming_links(
+        self, atom_handle: str, **kwargs
+    ) -> tuple[int, list[IncomingLinksT]] | list[IncomingLinksT]:
         links = self.db.incoming_set.get(atom_handle, set())
         if kwargs.get("handles_only", False):
             return list(links)
-        else:
-            return [self.get_atom(handle, **kwargs) for handle in links]
+        return [self.get_atom(handle, **kwargs) for handle in links]
 
-    def get_matched_type_template(self, template: List[Any], **kwargs) -> List[Tuple]:
+    def get_matched_type_template(
+        self, template: list[Any], **kwargs
+    ) -> (
+        list[tuple[str, tuple[str, ...]]]
+        | tuple[int, list[str] | list[str]]
+        | list[str]
+        | list[str]  # TODO(angelo): simplify this return type
+    ):
         template = self._build_named_type_hash_template(template)
         template_hash = ExpressionHasher.composite_hash(template)
         templates_matched = list(self.db.templates.get(template_hash, set()))
@@ -408,55 +598,71 @@ class InMemoryDB(AtomDB):
             return self._filter_non_toplevel(templates_matched)
         return templates_matched
 
-    def get_matched_type(self, link_type: str, **kwargs) -> List[Tuple]:
+    def get_matched_type(
+        self, link_type: str, **kwargs
+    ) -> (
+        list[tuple[str, tuple[str, ...]]]
+        | tuple[int, list[str] | list[str]]
+        | list[str]
+        | list[str]  # TODO(angelo): simplify this return type
+    ):
         link_type_hash = ExpressionHasher.named_type_hash(link_type)
         templates_matched = list(self.db.templates.get(link_type_hash, set()))
         if kwargs.get("toplevel_only"):
             return self._filter_non_toplevel(templates_matched)
         return templates_matched
 
-    def get_atoms_by_field(self, query: List[OrderedDict[str, str]]) -> List[str]:
+    def get_atoms_by_field(self, query: list[OrderedDict[str, str]]) -> list[str]:
         raise NotImplementedError()
 
     def get_atoms_by_index(
         self,
         index_id: str,
-        query: List[OrderedDict[str, str]],
-        cursor: Optional[int] = 0,
-        chunk_size: Optional[int] = 500,
-    ) -> List[str]:
+        query: list[OrderedDict[str, str]],
+        cursor: int | None = 0,
+        chunk_size: int | None = 500,
+    ) -> list[str]:
         raise NotImplementedError()
 
     def get_atoms_by_text_field(
-        self, text_value: str, field: Optional[str] = None, text_index_id: Optional[str] = None
-    ) -> List[str]:
+        self, text_value: str, field: str | None = None, text_index_id: str | None = None
+    ) -> list[str]:
         raise NotImplementedError()
 
-    def get_node_by_name_starting_with(self, node_type: str, startswith: str) -> List[str]:
+    def get_node_by_name_starting_with(self, node_type: str, startswith: str) -> list[str]:
         raise NotImplementedError()
 
     def get_atom(
         self, handle: str, **kwargs
-    ) -> Union[Tuple[Dict[str, Any], List[Dict[str, Any]]], Dict[str, Any]]:
+    ) -> (
+        dict[str, Any]
+        | tuple[
+            dict[str, Any],
+            list[
+                dict[str, Any]
+                | tuple[dict[str, Any], list[dict[str, Any]]]
+                | tuple[dict[str, Any], list[tuple[dict[Any, Any], list[Any]]]]
+            ],
+        ]  # TODO(angelo,andre): simplify this return type
+    ):
         document = self.db.node.get(handle)
         if document is None:
             document = self._get_link(handle)
         if document:
             if not kwargs.get("no_target_format", False):
                 return self._transform_to_target_format(document, **kwargs)
-            else:
-                return document
-        else:
-            logger().error(
-                f"Failed to retrieve atom for handle: {handle}. "
-                f"This link may not exist. - Details: {kwargs}"
-            )
-            raise AtomDoesNotExist(
-                message="Nonexistent atom",
-                details=f"handle: {handle}",
-            )
+            return document
 
-    def get_atom_type(self, handle: str) -> str:
+        logger().error(
+            f"Failed to retrieve atom for handle: {handle}. "
+            f"This link may not exist. - Details: {kwargs}"
+        )
+        raise AtomDoesNotExist(
+            message="Nonexistent atom",
+            details=f"handle: {handle}",
+        )
+
+    def get_atom_type(self, handle: str) -> str | None:
         atom = self.db.node.get(handle)
 
         if atom is None:
@@ -465,7 +671,9 @@ class InMemoryDB(AtomDB):
         if atom is not None:
             return atom[FieldNames.TYPE_NAME]
 
-    def get_atom_as_dict(self, handle: str, arity: Optional[int] = 0) -> Dict[str, Any]:
+        return None
+
+    def get_atom_as_dict(self, handle: str, arity: int | None = 0) -> dict[str, Any]:
         atom = self.db.node.get(handle)
         if atom is not None:
             return {
@@ -486,7 +694,7 @@ class InMemoryDB(AtomDB):
             details=f"handle: {handle}",
         )
 
-    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Dict[str, int]:
+    def count_atoms(self, parameters: dict[str, Any] | None = None) -> dict[str, int]:
         node_count = len(self.db.node)
         link_count = len(self.db.link)
         atom_count = node_count + link_count
@@ -505,19 +713,19 @@ class InMemoryDB(AtomDB):
             templates={},
         )
 
-    def add_node(self, node_params: Dict[str, Any]) -> Dict[str, Any]:
+    def add_node(self, node_params: dict[str, Any]) -> dict[str, Any]:
         handle, node = self._add_node(node_params)
         self.db.node[handle] = node
         self._update_index(node)
         return node
 
-    def add_link(self, link_params: Dict[str, Any], toplevel: bool = True) -> Dict[str, Any]:
-        handle, link, targets = self._add_link(link_params, toplevel)
+    def add_link(self, link_params: dict[str, Any], toplevel: bool = True) -> dict[str, Any]:
+        handle, link, _ = self._add_link(link_params, toplevel)
         self.db.link[handle] = link
         self._update_index(link)
         return link
 
-    def reindex(self, pattern_index_templates: Optional[Dict[str, Dict[str, Any]]] = None):
+    def reindex(self, pattern_index_templates: dict[str, dict[str, Any]] | None = None) -> None:
         raise NotImplementedError()
 
     def delete_atom(self, handle: str, **kwargs) -> None:
@@ -527,12 +735,13 @@ class InMemoryDB(AtomDB):
             handles = self.db.incoming_set.pop(handle, set())
 
             if handles:
-                for handle in handles:
-                    self._delete_link_and_update_index(handle)
+                for h in handles:
+                    self._delete_link_and_update_index(h)
         else:
             try:
                 self._delete_link_and_update_index(handle)
             except AtomDoesNotExist:
+                # pylint: disable=raise-missing-from
                 logger().error(
                     f"Failed to delete atom for handle: {handle}. "
                     f"This atom may not exist. - Details: {kwargs}"
@@ -545,14 +754,14 @@ class InMemoryDB(AtomDB):
     def create_field_index(
         self,
         atom_type: str,
-        fields: List[str],
-        named_type: Optional[str] = None,
-        composite_type: Optional[List[Any]] = None,
-        index_type: Optional[FieldIndexType] = None,
+        fields: list[str],
+        named_type: str | None = None,
+        composite_type: list[Any] | None = None,
+        index_type: FieldIndexType | None = None,
     ) -> str:
         pass
 
-    def bulk_insert(self, documents: List[Dict[str, Any]]) -> None:
+    def bulk_insert(self, documents: list[dict[str, Any]]) -> None:
         try:
             for document in documents:
                 handle = document[FieldNames.ID_HASH]
@@ -561,11 +770,10 @@ class InMemoryDB(AtomDB):
                 else:
                     self.db.link[handle] = document
                 self._update_index(document)
-        except Exception:
-            logger().error("Error bulk inserting documents")
-            return None
+        except Exception as e:  # pylint: disable=broad-except
+            logger().error(f"Error bulk inserting documents: {str(e)}")
 
-    def retrieve_all_atoms(self) -> List[Dict[str, Any]]:
+    def retrieve_all_atoms(self) -> list[dict[str, Any]] | list[tuple[str, Any]]:
         try:
             answer = list(self.db.node.items())
             answer.extend(list(self.db.link.items()))


### PR DESCRIPTION
Progress on ticket #161 

Refactors `ram_only.py`:
1. Applies `black` formatting.
2. Ensures lines width at max 100 chars.
3. Adds and fixes type annotations, mainly returns.
4. Applies new standard of type annotations (i.e. `dict[A, B] | None` instead of `Optional[Dict[A, B]]`.
5. Adds and/or fixes docstrings.
6. Ensures the file passes green through `pylint`.
7. Fixes some typos.
8. Left some `TODO` comments for future evaluation.
