### PR TITLE
[#161] refactoring `redis_mongo_db.py` and fixing small logic stuff

### DIFF
--- a/hyperon_das_atomdb/adapters/redis_mongo_db.py
+++ b/hyperon_das_atomdb/adapters/redis_mongo_db.py
@@ -1,10 +1,19 @@
+"""
+This module provides a concrete implementation of the AtomDB using Redis and MongoDB.
+
+It includes classes and methods for managing nodes and links, handling database connections,
+and performing various database operations such as creating indexes, retrieving documents,
+and updating indexes. The module integrates with MongoDB for persistent storage and Redis
+for caching and fast access to frequently used data.
+"""
+
 import base64
 import collections
 import pickle
 import sys
 from copy import deepcopy
 from enum import Enum
-from typing import Any, Dict, Iterable, List, Optional, OrderedDict, Tuple, Union
+from typing import Any, Iterable, Optional, OrderedDict
 
 from pymongo import ASCENDING, MongoClient
 from pymongo import errors as pymongo_errors
@@ -31,17 +40,31 @@ from hyperon_das_atomdb.logger import logger
 from hyperon_das_atomdb.utils.expression_hasher import ExpressionHasher
 
 
-def _build_redis_key(prefix, key):
+def _build_redis_key(prefix: str, key: str) -> str:
+    """
+    Build a Redis key by concatenating the given prefix and key with a colon separator.
+
+    Args:
+        prefix (str): The prefix to be used in the Redis key.
+        key (str): The key to be concatenated with the prefix.
+
+    Returns:
+        str: The concatenated Redis key.
+    """
     return prefix + ":" + key
 
 
 class MongoCollectionNames(str, Enum):
+    """Enum for MongoDB collection names used in the AtomDB."""
+
     ATOMS = 'atoms'
     ATOM_TYPES = 'atom_types'
     DAS_CONFIG = 'das_config'
 
 
 class KeyPrefix(str, Enum):
+    """Enum for key prefixes used in Redis."""
+
     INCOMING_SET = 'incoming_set'
     OUTGOING_SET = 'outgoing_set'
     PATTERNS = 'patterns'
@@ -51,55 +74,107 @@ class KeyPrefix(str, Enum):
 
 
 class MongoIndexType(str, Enum):
+    """Enum for MongoDB index types."""
+
     FIELD = 'field'
     COMPOUND = 'compound'
     TEXT = 'text'
 
 
 class NodeDocuments:
-    def __init__(self, collection) -> None:
+    """Class for managing node documents in MongoDB."""
+
+    def __init__(self, collection: Collection) -> None:
+        """
+        Initialize the NodeDocuments class with a MongoDB collection.
+
+        Args:
+            collection (Collection): The MongoDB collection to manage node documents.
+
+        Returns:
+            None
+        """
         self.mongo_collection = collection
         self.cached_nodes = {}
         self.count = 0
 
     def add(self) -> None:
+        """
+        Increment the count of node documents managed by this instance.
+
+        Returns:
+            None
+        """
         self.count += 1
 
-    def get(self, handle, default_value):
+    def get(self, handle: str, default_value: Any = None) -> Any:
+        """
+        Retrieve a node document from the MongoDB collection using the given handle.
+
+        Args:
+            handle (str): The unique identifier for the node document.
+            default_value (Any): The value to return if the node document is not found.
+                Defaults to None.
+
+        Returns:
+            The node document if found, otherwise the default value.
+        """
         mongo_filter = {FieldNames.ID_HASH: handle}
         node = self.mongo_collection.find_one(mongo_filter)
         return node if node else default_value
 
-    def size(self):
+    def size(self) -> int:
+        """
+        Return the count of node documents managed by this instance.
+
+        Returns:
+            int: The count of node documents.
+        """
         return self.count
 
-    def values(self):
+    def values(self) -> Iterable[dict[str, Any]]:
+        """
+        Yield all node documents from the MongoDB collection.
+
+        Returns:
+            generator: A generator yielding each document in the MongoDB collection.
+        """
         for document in self.mongo_collection.find():
             yield document
 
 
 class _HashableDocument:
-    def __init__(self, base: Dict[str, Any]):
+    """Class for making documents hashable."""
+
+    def __init__(self, base: dict[str, Any]):
         self.base = base
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.base["_id"])
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.base)
 
 
 class MongoDBIndex(Index):
+    """Class for managing MongoDB indexes."""
+
     def __init__(self, collection: Collection) -> None:
+        """
+        Initialize the NodeDocuments class with a MongoDB collection.
+
+        Args:
+            collection (Collection): The MongoDB collection to manage node documents.
+        """
         self.collection = collection
 
     def create(
         self,
         atom_type: str,
-        fields: List[str],
+        fields: list[str],
         index_type: Optional[MongoIndexType] = None,
         **kwargs,
-    ) -> Tuple[str, Any]:
+    ) -> tuple[str, Any]:
         conditionals = {}
         if fields is None or len(fields) == 0:
             raise ValueError("Fields can not be empty or None")
@@ -145,15 +220,19 @@ class MongoDBIndex(Index):
 class RedisMongoDB(AtomDB):
     """A concrete implementation using Redis and Mongo database"""
 
+    mongo_db: Database
+
     def __repr__(self) -> str:
         return "<Atom database RedisMongo>"  # pragma no cover
 
-    def __init__(self, **kwargs: Optional[Dict[str, Any]]) -> None:
-        """
-        Initialize an instance of a custom class with Redis and MongoDB connections.
-        """
+    def __init__(self, **kwargs: Optional[dict[str, Any]]) -> None:
+        """Initialize an instance of a custom class with Redis and MongoDB connections."""
+        self.pattern_index_templates: dict[str, dict[str, Any]] | None = None
         self.database_name = 'das'
-        self._setup_databases(**kwargs)
+
+        # _setup_databases is called here and **kwargs are passed to it with no previous validation
+        self._setup_databases(**kwargs)  # TODO(angelo,andre): validate kwargs?
+
         self.mongo_atoms_collection = self.mongo_db.get_collection(MongoCollectionNames.ATOMS)
         self.mongo_types_collection = self.mongo_db.get_collection(MongoCollectionNames.ATOM_TYPES)
         self.all_mongo_collections = [
@@ -161,10 +240,19 @@ class RedisMongoDB(AtomDB):
             (MongoCollectionNames.ATOM_TYPES, self.mongo_types_collection),
         ]
         self.mongo_das_config_collection = None
-        self.wildcard_hash = ExpressionHasher._compute_hash(WILDCARD)
-        self.named_type_hash = {}
-        self.typedef_mark_hash = ExpressionHasher._compute_hash(":")
-        self.typedef_base_type_hash = ExpressionHasher._compute_hash("Type")
+
+        # TODO(angelo,andre): remove '_' from `ExpressionHasher._compute_hash` method?
+        self.wildcard_hash = ExpressionHasher._compute_hash(
+            WILDCARD
+        )  # pylint: disable=protected-access
+        self.typedef_mark_hash = ExpressionHasher._compute_hash(
+            ":"
+        )  # pylint: disable=protected-access
+        self.typedef_base_type_hash = ExpressionHasher._compute_hash(
+            "Type"
+        )  # pylint: disable=protected-access
+
+        self.named_type_hash: dict[str, str] = {}
         self.hash_length = len(self.typedef_base_type_hash)
         self.typedef_composite_type_hash = ExpressionHasher.composite_hash(
             [
@@ -182,21 +270,41 @@ class RedisMongoDB(AtomDB):
         self._setup_indexes()
         logger().info("Database setup finished")
 
+    # this method defines keyword arguments but also accepts **kwargs (which is not used)
+    # TODO(angelo,andre): validate **kwargs? remove **kwargs?
     def _setup_databases(
         self,
-        mongo_hostname='localhost',
-        mongo_port=27017,
-        mongo_username='mongo',
-        mongo_password='mongo',
-        mongo_tls_ca_file=None,
-        redis_hostname='localhost',
-        redis_port=6379,
-        redis_username=None,
-        redis_password=None,
-        redis_cluster=True,
-        redis_ssl=True,
+        mongo_hostname: str = 'localhost',
+        mongo_port: int = 27017,
+        mongo_username: str = 'mongo',
+        mongo_password: str = 'mongo',
+        mongo_tls_ca_file: str | None = None,
+        redis_hostname: str = 'localhost',
+        redis_port: int = 6379,
+        redis_username: str | None = None,
+        redis_password: str | None = None,
+        redis_cluster: bool = True,
+        redis_ssl: bool = True,
         **kwargs,
     ) -> None:
+        """
+        Set up connections to MongoDB and Redis databases with the provided parameters.
+
+        Args:
+            mongo_hostname (str): The hostname for the MongoDB server. Defaults to 'localhost'.
+            mongo_port (int): The port number for the MongoDB server. Defaults to 27017.
+            mongo_username (str): The username for MongoDB authentication. Defaults to 'mongo'.
+            mongo_password (str): The password for MongoDB authentication. Defaults to 'mongo'.
+            mongo_tls_ca_file (str | None): The path to the TLS CA file for MongoDB.
+                Defaults to None.
+            redis_hostname (str): The hostname for the Redis server. Defaults to 'localhost'.
+            redis_port (int): The port number for the Redis server. Defaults to 6379.
+            redis_username (str | None): The username for Redis authentication. Defaults to None.
+            redis_password (str | None): The password for Redis authentication. Defaults to None.
+            redis_cluster (bool): Whether to use Redis in cluster mode. Defaults to True.
+            redis_ssl (bool): Whether to use SSL for Redis connection. Defaults to True.
+            **kwargs: Additional keyword arguments.
+        """
         self.mongo_db = self._connection_mongo_db(
             mongo_hostname,
             mongo_port,
@@ -215,46 +323,76 @@ class RedisMongoDB(AtomDB):
 
     def _connection_mongo_db(
         self,
-        mongo_hostname,
-        mongo_port,
-        mongo_username,
-        mongo_password,
-        mongo_tls_ca_file,
+        mongo_hostname: str,
+        mongo_port: int,
+        mongo_username: str,
+        mongo_password: str,
+        mongo_tls_ca_file: str | None,
     ) -> Database:
-        message = f"Connecting to MongoDB at {mongo_username}:{mongo_password}@{mongo_hostname}:{mongo_port}"
-        if mongo_tls_ca_file:
-            message += f"?tls=true&tlsCAFile={mongo_tls_ca_file}"
-        logger().info(message)
+        """
+        Establish a connection to the MongoDB database using the provided parameters.
+
+        This method constructs a MongoDB connection URL using the provided hostname, port,
+        username, password, and optional TLS CA file. It attempts to connect to the MongoDB
+        database and returns the connected database instance. If an error occurs during the
+        connection, it logs the error and raises a ConnectionMongoDBException.
+
+        Args:
+            mongo_hostname (str): The hostname for the MongoDB server.
+            mongo_port (int): The port number for the MongoDB server.
+            mongo_username (str): The username for MongoDB authentication.
+            mongo_password (str): The password for MongoDB authentication.
+            mongo_tls_ca_file (str | None): The path to the TLS CA file for MongoDB. Defaults to None.
+
+        Returns:
+            Database: The connected MongoDB database instance.
+
+        Raises:
+            ConnectionMongoDBException: If there is an error creating the MongoDB client.
+        """
+        mongo_url = f"mongodb://{mongo_username}:{mongo_password}@{mongo_hostname}:{mongo_port}"
+        if mongo_tls_ca_file:  # aws
+            mongo_url += (
+                f"?tls=true&tlsCAFile={mongo_tls_ca_file}"
+                "&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
+            )
+        logger().info(f"Connecting to MongoDB at {mongo_url}")
         try:
-            if mongo_tls_ca_file:
-                self.mongo_db = MongoClient(
-                    f"mongodb://{mongo_username}:{mongo_password}@{mongo_hostname}:{mongo_port}?tls=true&tlsCAFile={mongo_tls_ca_file}&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
-                )[
-                    self.database_name
-                ]  # aws
-            else:
-                self.mongo_db = MongoClient(
-                    f"mongodb://{mongo_username}:{mongo_password}@{mongo_hostname}:{mongo_port}"
-                )[self.database_name]
+            self.mongo_db = MongoClient(mongo_url)[self.database_name]
             return self.mongo_db
         except ValueError as e:
-            logger().error(
-                f'An error occourred while creating a MongoDB client - Details: {str(e)}'
-            )
+            logger().error(f'An error occurred while creating a MongoDB client - Details: {str(e)}')
             raise ConnectionMongoDBException(message="error creating a MongoClient", details=str(e))
 
+    @staticmethod
     def _connection_redis(
-        self,
-        redis_hostname,
-        redis_port,
-        redis_username,
-        redis_password,
-        redis_cluster,
-        redis_ssl,
-    ) -> Redis:
+        redis_hostname: str,
+        redis_port: int,
+        redis_username: str,
+        redis_password: str,
+        redis_cluster: bool = False,
+        redis_ssl: bool = False,
+    ) -> Redis | RedisCluster:
+        """
+        Establish a connection to the Redis database using the provided parameters.
+
+        Args:
+            redis_hostname (str): The hostname for the Redis server.
+            redis_port (int): The port number for the Redis server.
+            redis_username (str): The username for Redis authentication.
+            redis_password (str): The password for Redis authentication.
+            redis_cluster (bool): Whether to use Redis in cluster mode. Defaults to False.
+            redis_ssl (bool): Whether to use SSL for Redis connection. Defaults to False.
+
+        Returns:
+            Redis | RedisCluster: The connected Redis or RedisCluster instance.
+        """
         redis_type = 'Redis cluster' if redis_cluster else 'Standalone Redis'
 
-        message = f"Connecting to {redis_type} at {redis_username}:{redis_password}@{redis_hostname}:{redis_port}. ssl: {redis_ssl}"
+        message = (
+            f"Connecting to {redis_type} at "
+            f"{redis_username}:{redis_password}@{redis_hostname}:{redis_port}. ssl: {redis_ssl}"
+        )
 
         logger().info(message)
 
@@ -274,7 +412,16 @@ class RedisMongoDB(AtomDB):
         else:
             return Redis(**redis_connection)
 
-    def _setup_indexes(self):
+    def _setup_indexes(self) -> None:
+        """
+        Set up the default and custom pattern index templates for the database.
+
+        This method initializes the default pattern index templates based on various
+        combinations of named type and selected positions. If the DAS_CONFIG collection
+        exists in the MongoDB database, it retrieves the custom pattern index templates
+        from the collection. Otherwise, it sets the pattern index templates to None.
+        Additionally, it creates a field index for node names.
+        """
         self.default_pattern_index_templates = []
         for named_type in [True, False]:
             for pos0 in [True, False]:
@@ -283,11 +430,12 @@ class RedisMongoDB(AtomDB):
                         if named_type and pos0 and pos1 and pos2:
                             # not a pattern but an actual atom
                             continue
-                        template = {}
-                        template[FieldNames.TYPE_NAME] = named_type
-                        template["selected_positions"] = [
-                            i for i, pos in enumerate([pos0, pos1, pos2]) if pos
-                        ]
+                        template = {
+                            FieldNames.TYPE_NAME: named_type,
+                            "selected_positions": [
+                                i for i, pos in enumerate([pos0, pos1, pos2]) if pos
+                            ],
+                        }
                         self.default_pattern_index_templates.append(template)
         if MongoCollectionNames.DAS_CONFIG in self.mongo_db.list_collection_names():
             self.pattern_index_templates = self.mongo_das_config_collection.find_one(
@@ -299,53 +447,127 @@ class RedisMongoDB(AtomDB):
         # NOTE creating index for name search
         self.create_field_index('node', fields=['name'])
 
-    def _get_atom_type_hash(self, atom_type):
+    def _get_atom_type_hash(self, atom_type: str) -> str:
+        """
+        Retrieve the hash for the given atom type.
+
+        This method checks if the hash for the specified atom type is already cached.
+        If not, it computes the hash using the ExpressionHasher and caches it for
+        future use.
+
+        Args:
+            atom_type (str): The type of the atom for which the hash is to be retrieved.
+
+        Returns:
+            str: The hash corresponding to the given atom type.
+        """
         # TODO: implement a proper mongo collection to atom types so instead
         #      of this lazy hashmap, we should load the hashmap during prefetch
-        named_type_hash = self.named_type_hash.get(atom_type, None)
+        named_type_hash: str | None = self.named_type_hash.get(atom_type, None)
         if named_type_hash is None:
             named_type_hash = ExpressionHasher.named_type_hash(atom_type)
             self.named_type_hash[atom_type] = named_type_hash
         return named_type_hash
 
-    def _retrieve_document(self, handle: str) -> dict:
+    def _retrieve_document(self, handle: str) -> dict[str, Any] | None:
+        """
+        Retrieve a document from the MongoDB collection using the given handle.
+
+        This method searches for a document in the MongoDB collection with the specified
+        handle. If the document is found and it is a link, it adds the targets to the
+        document before returning it.
+
+        Args:
+            handle (str): The unique identifier for the document to be retrieved.
+
+        Returns:
+            dict[str, Any] | None: The retrieved document if found, otherwise None.
+        """
         mongo_filter = {FieldNames.ID_HASH: handle}
-        document = self.mongo_atoms_collection.find_one(mongo_filter)
+
+        # TODO(angelo,andre): remove this unused line?
+        # document = self.mongo_atoms_collection.find_one(mongo_filter)
+
         if document := self.mongo_atoms_collection.find_one(mongo_filter):
             if self._is_document_link(document):
                 document["targets"] = self._get_document_keys(document)
             return document
         return None
 
-    def _build_named_type_hash_template(self, template: Union[str, List[Any]]) -> List[Any]:
+    def _build_named_type_hash_template(
+        self, template: str | list[str | list[str] | list[list[str]]]
+    ) -> str | list[str | list[str] | list[list[str]]]:  # TODO(angelo,andre): simplify this return
+        """
+        Build a named type hash template from the given template.
+
+        This method processes the provided template, which can be a string or a nested list
+        of strings, and converts it into a hash template. If the template is a string, it
+        retrieves the hash for the named type. If the template is a list, it recursively
+        processes each element in the list to build the hash template.
+
+        Args:
+            template (str | list[str | list[str] | ...]): The template to be processed into a
+                hash template. It can be a string representing a named type or a nested list
+                of strings representing multiple named types.
+
+        Returns:
+            str | list[str | list[str] | ...]: The processed hash template corresponding to the
+                provided template.
+        """
         if isinstance(template, str):
             return self._get_atom_type_hash(template)
         else:
+            assert isinstance(
+                template, collections.abc.Iterable
+            ), "template must be a string or an iterable of strings"
             answer = []
             for element in template:
                 v = self._build_named_type_hash_template(element)
                 answer.append(v)
             return answer
 
-    def _get_document_keys(self, document: Dict) -> List[str]:
-        answer = document.get(FieldNames.KEYS, None)
+    @staticmethod
+    def _get_document_keys(document: dict[str, Any]) -> list[str]:
+        """
+        Retrieve the keys from the given document.
+
+        This method extracts the keys from the provided document. If the keys are not
+        directly available, it constructs them by iterating through the document with
+        a specific prefix pattern.
+
+        Args:
+            document (dict[str, Any]): The document from which to retrieve the keys.
+
+        Returns:
+            list[str]: A list of keys extracted from the document.
+        """
+        answer: list[str] | None = document.get(FieldNames.KEYS, None)
         if answer is not None:
             return answer
+
         answer = []
         index = 0
-        while True:
-            key = document.get(f"{FieldNames.KEY_PREFIX.value}_{index}", None)
-            if key is None:
-                return answer
-            else:
-                answer.append(key)
+        while (key := document.get(f"{FieldNames.KEY_PREFIX.value}_{index}", None)) is not None:
+            answer.append(key)
             index += 1
+        return answer
 
-    def _filter_non_toplevel(self, matches: list) -> list:
-        matches_toplevel_only = []
+    def _filter_non_toplevel(self, matches: list[str]) -> list[str]:
+        """
+        Filter out non-toplevel links from the given list of matches.
+
+        This method iterates through the provided list of matches, retrieves the corresponding
+        link documents, and checks if each link is marked as toplevel. Only the toplevel links
+        are included in the returned list.
+
+        Args:
+            matches (list[str]): A list of link handles to be filtered.
+
+        Returns:
+            list[str]: A list of handles corresponding to toplevel links.
+        """
+        matches_toplevel_only: list[str] = []
         if len(matches) > 0:
-            # if isinstance(matches[0], list):
-            #    matches = matches[0]
             for match in matches:
                 link_handle = match[0]
                 link = self._retrieve_document(link_handle)
@@ -360,7 +582,8 @@ class RedisMongoDB(AtomDB):
             return document[FieldNames.ID_HASH]
         else:
             logger().error(
-                f'Failed to retrieve node handle for {node_type}:{node_name}. This node may not exist.'
+                f'Failed to retrieve node handle for {node_type}:{node_name}. '
+                f'This node may not exist.'
             )
             raise AtomDoesNotExist(
                 message="Nonexistent atom",
@@ -371,7 +594,8 @@ class RedisMongoDB(AtomDB):
         answer = self._retrieve_name(node_handle)
         if not answer:
             logger().error(
-                f'Failed to retrieve node name for handle: {node_handle}. The handle may be invalid or the corresponding node does not exist.'
+                f'Failed to retrieve node name for handle: {node_handle}. '
+                'The handle may be invalid or the corresponding node does not exist.'
             )
             raise ValueError(f"Invalid handle: {node_handle}")
         return answer
@@ -380,7 +604,7 @@ class RedisMongoDB(AtomDB):
         document = self.get_atom(node_handle)
         return document[FieldNames.TYPE_NAME]
 
-    def get_node_by_name(self, node_type: str, substring: str) -> str:
+    def get_node_by_name(self, node_type: str, substring: str) -> list[str]:
         node_type_hash = self._get_atom_type_hash(node_type)
         mongo_filter = {
             FieldNames.COMPOSITE_TYPE_HASH: node_type_hash,
@@ -391,7 +615,7 @@ class RedisMongoDB(AtomDB):
             for document in self.mongo_atoms_collection.find(mongo_filter)
         ]
 
-    def get_atoms_by_field(self, query: List[OrderedDict[str, str]]) -> List[str]:
+    def get_atoms_by_field(self, query: list[OrderedDict[str, str]]) -> list[str]:
         mongo_filter = collections.OrderedDict([(q['field'], q['value']) for q in query])
         return [
             document[FieldNames.ID_HASH]
@@ -401,10 +625,26 @@ class RedisMongoDB(AtomDB):
     def get_atoms_by_index(
         self,
         index_id: str,
-        query: List[OrderedDict[str, str]],
+        query: list[OrderedDict[str, str]],
         cursor: Optional[int] = 0,
         chunk_size: Optional[int] = 500,
-    ) -> Tuple[int, List[str]]:
+    ) -> (  # TODO(angelo,andre): simplify this return type
+        list[str]
+        | tuple[
+            int,
+            list[
+                dict[str, Any]
+                | tuple[
+                    dict[str, Any],
+                    list[
+                        dict[str, Any]
+                        | tuple[dict[str, Any], list[dict[str, Any]]]
+                        | tuple[dict[str, Any], list[tuple[dict[Any, Any], list[Any]]]]
+                    ],
+                ]
+            ],
+        ]
+    ):
         mongo_filter = collections.OrderedDict([(q['field'], q['value']) for q in query])
         return self._get_atoms_by_index(
             index_id, cursor=cursor, chunk_size=chunk_size, **mongo_filter
@@ -415,7 +655,7 @@ class RedisMongoDB(AtomDB):
         text_value: str,
         field: Optional[str] = None,
         text_index_id: Optional[str] = None,
-    ) -> List[str]:
+    ) -> list[str]:
         if field is not None:
             mongo_filter = {
                 field: {'$regex': text_value},
@@ -447,7 +687,7 @@ class RedisMongoDB(AtomDB):
             for document in self.mongo_atoms_collection.find(mongo_filter)
         ]
 
-    def get_all_nodes(self, node_type: str, names: bool = False) -> List[str]:
+    def get_all_nodes(self, node_type: str, names: bool = False) -> list[str]:
         if names:
             return [
                 document[FieldNames.NODE_NAME]
@@ -459,7 +699,7 @@ class RedisMongoDB(AtomDB):
                 for document in self.mongo_atoms_collection.find({FieldNames.TYPE_NAME: node_type})
             ]
 
-    def get_all_links(self, link_type: str, **kwargs) -> Tuple[int, List[str]]:
+    def get_all_links(self, link_type: str, **kwargs) -> tuple[int, list[str]]:
         pymongo_cursor = self.mongo_atoms_collection.find({FieldNames.TYPE_NAME: link_type})
 
         if kwargs.get('cursor') is not None:
@@ -479,25 +719,27 @@ class RedisMongoDB(AtomDB):
 
         return 0, [document[FieldNames.ID_HASH] for document in pymongo_cursor]
 
-    def get_link_handle(self, link_type: str, target_handles: List[str]) -> str:
+    def get_link_handle(self, link_type: str, target_handles: list[str]) -> str:
         link_handle = self.link_handle(link_type, target_handles)
         document = self._retrieve_document(link_handle)
         if document is not None:
             return document[FieldNames.ID_HASH]
         else:
             logger().error(
-                f'Failed to retrieve link handle for {link_type}:{target_handles}. This link may not exist.'
+                f'Failed to retrieve link handle for {link_type}:{target_handles}. '
+                'This link may not exist.'
             )
             raise AtomDoesNotExist(
                 message="Nonexistent atom",
                 details=f"{link_type}:{target_handles}",
             )
 
-    def get_link_targets(self, link_handle: str) -> List[str]:
+    def get_link_targets(self, link_handle: str) -> list[str]:
         answer = self._retrieve_outgoing_set(link_handle)
         if not answer:
             logger().error(
-                f'Failed to retrieve link targets for handle: {link_handle}. The handle may be invalid or the corresponding link does not exist.'
+                f'Failed to retrieve link targets for handle: {link_handle}. '
+                'The handle may be invalid or the corresponding link does not exist.'
             )
             raise ValueError(f"Invalid handle: {link_handle}")
         return answer
@@ -506,14 +748,21 @@ class RedisMongoDB(AtomDB):
         document = self._retrieve_document(link_handle)
         if document is None:
             logger().error(
-                'Failed to retrieve document for link handle: {link_handle}. The handle may be invalid or the corresponding link does not exist.'
+                'Failed to retrieve document for link handle: {link_handle}. '
+                'The handle may be invalid or the corresponding link does not exist.'
             )
             raise ValueError(f"Invalid handle: {link_handle}")
         return True
 
     def get_matched_links(
-        self, link_type: str, target_handles: List[str], **kwargs
-    ) -> Union[tuple, list]:
+        self, link_type: str, target_handles: list[str], **kwargs
+    ) -> (
+        list[str]
+        | list[list[str]]
+        | list[tuple[str, tuple[str, ...]]]
+        | tuple[int, list[str]]
+        | tuple[int, list[list[str]]]  # TODO(angelo): simplify this return type
+    ):
         if link_type != WILDCARD and WILDCARD not in target_handles:
             try:
                 link_handle = self.get_link_handle(link_type, target_handles)
@@ -545,7 +794,7 @@ class RedisMongoDB(AtomDB):
 
     def get_incoming_links(
         self, atom_handle: str, **kwargs
-    ) -> Union[Tuple[int, List[IncomingLinksT]], List[IncomingLinksT]]:
+    ) -> tuple[int, list[IncomingLinksT]] | list[IncomingLinksT]:
         cursor, links = self._retrieve_incoming_set(atom_handle, **kwargs)
 
         if kwargs.get('cursor') is not None:
@@ -559,10 +808,19 @@ class RedisMongoDB(AtomDB):
             else:
                 return [self.get_atom(handle, **kwargs) for handle in links]
 
-    def get_matched_type_template(self, template: List[Any], **kwargs) -> Union[tuple, list]:
+    def get_matched_type_template(
+        self, template: list[Any], **kwargs
+    ) -> (
+        list[tuple[str, tuple[str, ...]]]
+        | tuple[int, list[str] | list[str]]
+        | list[str]
+        | list[str]  # TODO(angelo): simplify this return type
+    ):
         try:
             template = self._build_named_type_hash_template(template)
             template_hash = ExpressionHasher.composite_hash(template)
+            cursor: int
+            templates_matched: list[str]
             cursor, templates_matched = self._retrieve_template(template_hash, **kwargs)
             toplevel_only = kwargs.get('toplevel_only', False)
             return self._process_matched_results(templates_matched, cursor, toplevel_only)
@@ -570,7 +828,14 @@ class RedisMongoDB(AtomDB):
             logger().error(f'Failed to get matched type template - Details: {str(exception)}')
             raise ValueError(str(exception))
 
-    def get_matched_type(self, link_type: str, **kwargs) -> Union[tuple, list]:
+    def get_matched_type(
+        self, link_type: str, **kwargs
+    ) -> (
+        list[tuple[str, tuple[str, ...]]]
+        | tuple[int, list[str] | list[str]]
+        | list[str]
+        | list[str]  # TODO(angelo): simplify this return type
+    ):
         named_type_hash = self._get_atom_type_hash(link_type)
         cursor, templates_matched = self._retrieve_template(named_type_hash, **kwargs)
         toplevel_only = kwargs.get('toplevel_only', False)
@@ -580,7 +845,19 @@ class RedisMongoDB(AtomDB):
         document = self.get_atom(link_handle)
         return document[FieldNames.TYPE_NAME]
 
-    def get_atom(self, handle: str, **kwargs) -> Dict[str, Any]:
+    def get_atom(
+        self, handle: str, **kwargs
+    ) -> (
+        dict[str, Any]
+        | tuple[
+            dict[str, Any],
+            list[
+                dict[str, Any]
+                | tuple[dict[str, Any], list[dict[str, Any]]]
+                | tuple[dict[str, Any], list[tuple[dict[Any, Any], list[Any]]]]
+            ],
+        ]  # TODO(angelo,andre): simplify this return type
+    ):
         document = self._retrieve_document(handle)
         if document:
             if not kwargs.get('no_target_format', False):
@@ -596,12 +873,11 @@ class RedisMongoDB(AtomDB):
                 details=f'handle: {handle}',
             )
 
-    def get_atom_type(self, handle: str) -> str:
+    def get_atom_type(self, handle: str) -> str | None:
         atom = self._retrieve_document(handle)
-        if atom is not None:
-            return atom[FieldNames.TYPE_NAME]
+        return atom[FieldNames.TYPE_NAME]
 
-    def get_atom_as_dict(self, handle) -> dict:
+    def get_atom_as_dict(self, handle: str, arity: int | None = 0) -> dict[str, Any]:
         answer = {}
         document = self._retrieve_document(handle)
         if document:
@@ -613,7 +889,7 @@ class RedisMongoDB(AtomDB):
                 answer["name"] = document["name"]
         return answer
 
-    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Dict[str, int]:
+    def count_atoms(self, parameters: dict[str, Any] | None = None) -> dict[str, int]:
         atom_count = self.mongo_atoms_collection.estimated_document_count()
         return_count = {'atom_count': atom_count}
         if parameters and parameters.get('precise'):
@@ -636,9 +912,9 @@ class RedisMongoDB(AtomDB):
         This method drops all collections in the MongoDB database and flushes
         all data from the Redis cache, effectively wiping the databases clean.
         """
-        collections = self.mongo_db.list_collection_names()
+        mongo_collections = self.mongo_db.list_collection_names()
 
-        for collection in collections:
+        for collection in mongo_collections:
             self.mongo_db[collection].drop()
 
         self.redis.flushall()
@@ -670,8 +946,8 @@ class RedisMongoDB(AtomDB):
 
                 buffer.clear()
 
-    def add_node(self, node_params: Dict[str, Any]) -> Dict[str, Any]:
-        handle, node = self._add_node(node_params)
+    def add_node(self, node_params: dict[str, Any]) -> dict[str, Any] | None:
+        _, node = self._add_node(node_params)
         if sys.getsizeof(node_params['name']) < self.max_mongo_db_document_size:
             _, buffer = self.mongo_bulk_insertion_buffer[MongoCollectionNames.ATOMS]
             buffer.add(_HashableDocument(node))
@@ -679,17 +955,18 @@ class RedisMongoDB(AtomDB):
                 self.commit()
             return node
         else:
-            logger().warn("Discarding atom whose name is too large: {node_name}")
+            logger().warning("Discarding atom whose name is too large: {node_name}")
+            return None
 
-    def add_link(self, link_params: Dict[str, Any], toplevel: bool = True) -> Dict[str, Any]:
-        handle, link, targets = self._add_link(link_params, toplevel)
+    def add_link(self, link_params: dict[str, Any], toplevel: bool = True) -> dict[str, Any]:
+        _, link, _ = self._add_link(link_params, toplevel)
         _, buffer = self.mongo_bulk_insertion_buffer[MongoCollectionNames.ATOMS]
         buffer.add(_HashableDocument(link))
         if len(buffer) >= self.mongo_bulk_insertion_limit:
             self.commit()
         return link
 
-    def _get_and_delete_links_by_handles(self, handles: List[str]) -> Dict[str, Any]:
+    def _get_and_delete_links_by_handles(self, handles: list[str]) -> list[dict[str, Any]]:
         documents = []
         for handle in handles:
             if document := self.mongo_atoms_collection.find_one_and_delete(
@@ -698,32 +975,106 @@ class RedisMongoDB(AtomDB):
                 documents.append(document)
         return documents
 
+    @staticmethod
     def _apply_index_template(
-        self, template: Dict[str, Any], named_type: str, targets: List[str], arity
-    ) -> List[List[str]]:
-        key = []
+        template: dict[str, Any], named_type: str, targets: list[str], arity: int
+    ) -> str:
+        """
+        Apply the index template to generate a Redis key.
+
+        This method constructs a Redis key by applying the provided index template. The key
+        is built using the named type and the targets, with specific positions selected based
+        on the template. The key is then hashed to create a unique identifier.
+
+        Args:
+            template (dict[str, Any]): The index template containing type name and selected
+                positions.
+            named_type (str): The named type to be included in the key.
+            targets (list[str]): The list of target handles to be included in the key.
+            arity (int): The arity of the link, indicating the number of targets.
+
+        Returns:
+            str: The generated Redis key after applying the index template.
+        """
         key = [WILDCARD] if template[FieldNames.TYPE_NAME] else [named_type]
         target_selected_pos = template["selected_positions"]
         for cursor in range(arity):
             key.append(WILDCARD if cursor in target_selected_pos else targets[cursor])
         return _build_redis_key(KeyPrefix.PATTERNS, ExpressionHasher.composite_hash(key))
 
-    def _retrieve_incoming_set(self, handle: str, **kwargs) -> Tuple[int, List[str]]:
+    def _retrieve_incoming_set(self, handle: str, **kwargs) -> tuple[int, list[str]]:
+        """
+        Retrieve the incoming set for the given handle from Redis.
+
+        This method constructs a Redis key using the provided handle and retrieves the members
+        of the incoming set associated with that key. It supports additional keyword arguments
+        for cursor-based pagination.
+
+        Args:
+            handle (str): The unique identifier for the atom whose incoming set is to be retrieved.
+            **kwargs: Additional keyword arguments for cursor-based pagination.
+
+        Returns:
+            tuple[int, list[str]]: A tuple containing the cursor position and a list of members
+                in the incoming set.
+        """
         key = _build_redis_key(KeyPrefix.INCOMING_SET, handle)
         cursor, members = self._get_redis_members(key, **kwargs)
-        return (cursor, [member for member in members])
+        return cursor, list(members)
 
     def _delete_smember_incoming_set(self, handle: str, smember: str) -> None:
+        """
+        Remove a specific member from the incoming set of the given handle in Redis.
+
+        This method constructs a Redis key using the provided handle and removes the specified
+        member from the incoming set associated with that key.
+
+        Args:
+            handle (str): The unique identifier for the atom whose incoming set member is to be
+                removed.
+            smember (str): The member to be removed from the incoming set.
+
+        Returns:
+            None
+        """
         key = _build_redis_key(KeyPrefix.INCOMING_SET, handle)
         self.redis.srem(key, smember)
 
-    def _retrieve_and_delete_incoming_set(self, handle: str) -> List[str]:
+    def _retrieve_and_delete_incoming_set(self, handle: str) -> list[str]:
+        """
+        Retrieve and delete the incoming set for the given handle from Redis.
+
+        This method constructs a Redis key using the provided handle, retrieves all members
+        of the incoming set associated with that key, and then deletes the key from Redis.
+
+        Args:
+            handle (str): The unique identifier for the atom whose incoming set is to be
+                retrieved and deleted.
+
+        Returns:
+            list[str]: A list of members in the incoming set before deletion.
+        """
         key = _build_redis_key(KeyPrefix.INCOMING_SET, handle)
-        data = [member for member in self.redis.smembers(key)]
+        data = list(self.redis.smembers(key))
         self.redis.delete(key)
         return data
 
-    def _retrieve_outgoing_set(self, handle: str, delete=False) -> List[str]:
+    def _retrieve_outgoing_set(self, handle: str, delete: bool = False) -> list[str]:
+        """
+        Retrieve the outgoing set for the given handle from Redis.
+
+        This method constructs a Redis key using the provided handle and retrieves the members
+        of the outgoing set associated with that key. If the delete flag is set to True, the
+        key is deleted from Redis after retrieving the members.
+
+        Args:
+            handle (str): The unique identifier for the atom whose outgoing set is to be retrieved.
+            delete (bool): Whether to delete the key from Redis after retrieving the members.
+                Defaults to False.
+
+        Returns:
+            list[str]: A list of members in the outgoing set.
+        """
         key = _build_redis_key(KeyPrefix.OUTGOING_SET, handle)
         if delete:
             value = self.redis.getdel(key)
@@ -731,27 +1082,58 @@ class RedisMongoDB(AtomDB):
             value = self.redis.get(key)
         if value is None:
             return []
-        arity = len(value) // self.hash_length
+        arity = len(value) // self.hash_length  # type: ignore
         return [
             value[(offset * self.hash_length) : ((offset + 1) * self.hash_length)]  # noqa: E203
             for offset in range(arity)
         ]
 
-    def _retrieve_name(self, handle: str) -> str:
+    def _retrieve_name(self, handle: str) -> str | None:
+        """
+        Retrieve the name associated with the given handle from Redis.
+
+        This method constructs a Redis key using the provided handle and retrieves the name
+        associated with that key. If the name is not found, it returns None.
+
+        Args:
+            handle (str): The unique identifier for the atom whose name is to be retrieved.
+
+        Returns:
+            str | None: The name associated with the given handle if found, otherwise None.
+        """
         key = _build_redis_key(KeyPrefix.NAMED_ENTITIES, handle)
         name = self.redis.get(key)
         if name:
-            return name
+            return name  # type: ignore
         else:
             return None
 
     def _retrieve_hash_targets_value(
         self, key_prefix: str, handle: str, **kwargs
-    ) -> Tuple[int, List[str]]:
+    ) -> tuple[int, list[str | list[str]]]:
+        """
+        Retrieve the hash targets value for the given handle from Redis.
+
+        This method constructs a Redis key using the provided key prefix and handle, and retrieves
+        the members associated with that key. It supports additional keyword arguments for
+        cursor-based pagination. If the members are not found, it returns an empty list. Otherwise,
+        it calculates the number of targets based on the length of the first member and returns
+        the cursor position and a list of members.
+
+        Args:
+            key_prefix (str): The prefix to be used in the Redis key.
+            handle (str): The unique identifier for the atom whose hash targets value is to be
+                retrieved.
+            **kwargs: Additional keyword arguments for cursor-based pagination.
+
+        Returns:
+            tuple[int, list[str | list[str]]]: A tuple containing the cursor position and a list
+                of members in the hash targets value.
+        """
         key = _build_redis_key(key_prefix, handle)
         cursor, members = self._get_redis_members(key, **kwargs)
         if len(members) == 0:
-            return (cursor, [])
+            return cursor, []
         else:
             n = len(next(iter(members))) // self.hash_length
             return (
@@ -769,27 +1151,91 @@ class RedisMongoDB(AtomDB):
                 ],
             )
 
-    def _retrieve_template(self, handle: str, **kwargs) -> Tuple[int, List[str]]:
+    def _retrieve_template(self, handle: str, **kwargs) -> tuple[int, list[str | list[str]]]:
+        """
+        Retrieve the template for the given handle from Redis.
+
+        This method constructs a Redis key using the provided handle and retrieves the members
+        associated with that key. It supports additional keyword arguments for cursor-based
+        pagination. If the members are not found, it returns an empty list. Otherwise, it
+        calculates the number of targets based on the length of the first member and returns
+        the cursor position and a list of members.
+
+        Args:
+            handle (str): The unique identifier for the atom whose template is to be retrieved.
+            **kwargs: Additional keyword arguments for cursor-based pagination.
+
+        Returns:
+            tuple[int, list[str | list[str]]]: A tuple containing the cursor position and a list
+                of members in the template.
+        """
         return self._retrieve_hash_targets_value(KeyPrefix.TEMPLATES, handle, **kwargs)
 
     def _delete_smember_template(self, handle: str, smember: str) -> None:
+        """
+        Remove a specific member from the template set of the given handle in Redis.
+
+        This method constructs a Redis key using the provided handle and removes the specified
+        member from the template set associated with that key.
+
+        Args:
+            handle (str): The unique identifier for the atom whose template member is to be
+                removed.
+            smember (str): The member to be removed from the template set.
+        """
         key = _build_redis_key(KeyPrefix.TEMPLATES, handle)
         self.redis.srem(key, smember)
 
-    def _retrieve_pattern(self, handle: str, **kwargs) -> Tuple[int, List[str]]:
+    def _retrieve_pattern(self, handle: str, **kwargs) -> tuple[int, list[str | list[str]]]:
+        """
+        Retrieve the pattern for the given handle from Redis.
+
+        This method constructs a Redis key using the provided handle and retrieves the members
+        associated with that key. It supports additional keyword arguments for cursor-based
+        pagination. If the members are not found, it returns an empty list. Otherwise, it
+        calculates the number of targets based on the length of the first member and returns
+        the cursor position and a list of members.
+
+        Args:
+            handle (str): The unique identifier for the atom whose pattern is to be retrieved.
+            **kwargs: Additional keyword arguments for cursor-based pagination.
+
+        Returns:
+            tuple[int, list[str | list[str]]]: A tuple containing the cursor position and a list
+                of members in the pattern.
+        """
         return self._retrieve_hash_targets_value(KeyPrefix.PATTERNS, handle, **kwargs)
 
-    def _retrieve_custom_index(self, index_id: str) -> dict:
+    def _retrieve_custom_index(self, index_id: str) -> dict[str, Any] | None:
+        """
+        Retrieve a custom index from Redis using the given index ID.
+
+        This method constructs a Redis key using the provided index ID and attempts to retrieve
+        the custom index associated with that key. The custom index is expected to be stored as
+        a base64-encoded, pickled dictionary. If the custom index is not found or if there is an
+        error during retrieval, appropriate logging is performed and the method returns None.
+
+        Args:
+            index_id (str): The unique identifier for the custom index to be retrieved.
+
+        Returns:
+            dict[str, Any] | None: The retrieved custom index as a dictionary if found, otherwise
+                None.
+
+        Raises:
+            ConnectionError: If there is an error connecting to Redis.
+            Exception: If there is an unexpected error during retrieval.
+        """
         try:
             key = _build_redis_key(KeyPrefix.CUSTOM_INDEXES, index_id)
-            custom_index_str = self.redis.get(key)
+            custom_index_str: str | None = self.redis.get(key)
 
             if custom_index_str is None:
                 logger().info(f"Custom index with ID {index_id} not found in Redis")
                 return None
 
             custom_index_bytes = base64.b64decode(custom_index_str)
-            custom_index = pickle.loads(custom_index_bytes)
+            custom_index: dict[str, Any] = pickle.loads(custom_index_bytes)
 
             if not isinstance(custom_index, dict):
                 logger().error(f"Custom index with ID {index_id} is not a dictionary")
@@ -803,7 +1249,7 @@ class RedisMongoDB(AtomDB):
             logger().error(f"Unexpected error retrieving custom index with ID {index_id}: {e}")
             raise e
 
-    def _get_redis_members(self, key, **kwargs) -> Tuple[int, list]:
+    def _get_redis_members(self, key, **kwargs) -> tuple[int, list]:
         """
         Retrieve members from a Redis set, with optional cursor-based paging.
 
@@ -814,7 +1260,7 @@ class RedisMongoDB(AtomDB):
                 chunk_size (int, optional): The size of each chunk to retrieve.
 
         Returns:
-            Tuple[int, list]: The cursor and a list of members retrieved from Redis.
+            tuple[int, list]: The cursor and a list of members retrieved from Redis.
         """
         if (cursor := kwargs.get('cursor')) is not None:
             chunk_size = kwargs.get('chunk_size', 1000)
@@ -825,14 +1271,38 @@ class RedisMongoDB(AtomDB):
 
         return cursor, members
 
-    def _update_atom_indexes(self, documents: Iterable[Dict[str, any]], **kwargs) -> None:
+    def _update_atom_indexes(self, documents: Iterable[dict[str, any]], **kwargs) -> None:
+        """
+        Update the indexes for the given documents in the database.
+
+        This method iterates through the provided documents and updates the corresponding
+        indexes. If a document is identified as a link, it updates the link index; otherwise,
+        it updates the node index.
+
+        Args:
+            documents (Iterable[dict[str, any]]): An iterable of documents to be indexed.
+            **kwargs: Additional keyword arguments for index updates.
+        """
         for document in documents:
             if self._is_document_link(document):
                 self._update_link_index(document, **kwargs)
             else:
                 self._update_node_index(document, **kwargs)
 
-    def _update_node_index(self, document: Dict[str, Any], **kwargs) -> None:
+    def _update_node_index(self, document: dict[str, Any], **kwargs) -> None:
+        """
+        Update the index for the given node document in the database.
+
+        This method updates the Redis index for the provided node document. It constructs a Redis
+        key using the document's handle and updates the node name in the Redis cache. If the
+        `delete_atom` flag is set to True, it deletes the Redis key and any associated incoming
+        links for the node.
+
+        Args:
+            document (dict[str, Any]): The node document to be indexed.
+            **kwargs: Additional keyword arguments for index updates. Supports `delete_atom` to
+                indicate whether the node should be deleted from the index.
+        """
         handle = document[FieldNames.ID_HASH]
         node_name = document[FieldNames.NODE_NAME]
         key = _build_redis_key(KeyPrefix.NAMED_ENTITIES, handle)
@@ -840,12 +1310,25 @@ class RedisMongoDB(AtomDB):
             self.redis.delete(key)
             if links_handle := self._retrieve_and_delete_incoming_set(handle):
                 documents = self._get_and_delete_links_by_handles(links_handle)
-                for document in documents:
-                    self._update_link_index(document, delete_atom=True)
+                for _document in documents:
+                    self._update_link_index(_document, delete_atom=True)
         else:
             self.redis.set(key, node_name)
 
-    def _update_link_index(self, document: Dict[str, Any], **kwargs) -> None:
+    def _update_link_index(self, document: dict[str, Any], **kwargs) -> None:
+        """
+        Update the index for the given link document in the database.
+
+        This method updates the Redis index for the provided link document. It constructs a Redis
+        key using the document's handle and updates the link targets in the Redis cache. If the
+        `delete_atom` flag is set to True, it deletes the Redis key and any associated incoming
+        links for the link.
+
+        Args:
+            document (dict[str, Any]): The link document to be indexed.
+            **kwargs: Additional keyword arguments for index updates. Supports `delete_atom` to
+                indicate whether the link should be deleted from the index.
+        """
         handle = document[FieldNames.ID_HASH]
         targets = self._get_document_keys(document)
         targets_str = "".join(targets)
@@ -903,8 +1386,29 @@ class RedisMongoDB(AtomDB):
                 self.redis.sadd(key, *incoming_buffer[handle])
 
     def _process_matched_results(
-        self, matched: list, cursor: int = None, toplevel_only: bool = False
-    ) -> Union[tuple, list]:
+        self, matched: list[str | list[str]], cursor: int | None = None, toplevel_only: bool = False
+    ) -> (
+        tuple[int, list[str] | list[str]]
+        | list[str]
+        | list[list[str]]  # TODO(angelo,andre): simplify this return type
+    ):
+        """
+        Process the matched results and filter them based on the toplevel_only flag.
+
+        This method processes the matched results by filtering out non-toplevel links if the
+        toplevel_only flag is set to True. It returns the filtered results along with the cursor
+        if provided.
+
+        Args:
+            matched (list[str | list[str]]): The list of matched results to be processed.
+            cursor (int | None): The cursor position for pagination. Defaults to None.
+            toplevel_only (bool): Flag indicating whether to filter out non-toplevel links.
+                Defaults to False.
+
+        Returns:
+            tuple[int, list[str] | list[str]] | list[str] | list[list[str]]: The processed matched
+                results, either as a tuple with the cursor and results or just the results.
+        """
         if toplevel_only:
             answer = self._filter_non_toplevel(matched)
         else:
@@ -915,13 +1419,41 @@ class RedisMongoDB(AtomDB):
         else:
             return answer
 
-    def _is_document_link(self, document: Dict[str, Any]) -> bool:
-        return True if FieldNames.COMPOSITE_TYPE in document else False
+    @staticmethod
+    def _is_document_link(document: dict[str, Any]) -> bool:
+        """
+        Determine if the given document is a link.
 
-    def _calculate_composite_type_hash(self, composite_type: List[Any]) -> str:
-        def calculate_composite_type_hashes(composite_type: List[Any]) -> List[str]:
+        This method checks if the provided document contains the `COMPOSITE_TYPE` field, which
+        indicates that the document is a link.
+
+        Args:
+            document (dict[str, Any]): The document to be checked.
+
+        Returns:
+            bool: True if the document is a link, False otherwise.
+        """
+        return FieldNames.COMPOSITE_TYPE in document
+
+    @staticmethod
+    def _calculate_composite_type_hash(composite_type: list[Any]) -> str:
+        """
+        Calculate the composite type hash for the given composite type.
+
+        This method computes the hash for the provided composite type by iterating through
+        the elements of the composite type. If an element is a list, it recursively calculates
+        the hash for the nested list. The final hash is generated using the ExpressionHasher.
+
+        Args:
+            composite_type (list[Any]): The composite type for which the hash is to be calculated.
+
+        Returns:
+            str: The calculated composite type hash.
+        """
+
+        def calculate_composite_type_hashes(_composite_type: list[Any]) -> list[str]:
             response = []
-            for t in composite_type:
+            for t in _composite_type:
                 if isinstance(t, list):
                     _hash = calculate_composite_type_hashes(t)
                     response.append(ExpressionHasher.composite_hash(_hash))
@@ -934,9 +1466,30 @@ class RedisMongoDB(AtomDB):
 
     def _retrieve_documents_by_index(
         self, collection: Collection, index_id: str, **kwargs
-    ) -> Tuple[int, List[Dict[str, Any]]]:
+    ) -> tuple[int, list[dict[str, Any]]]:
+        """
+        Retrieve documents from the specified MongoDB collection using the given index.
+
+        This method retrieves documents from the provided MongoDB collection by utilizing the
+        specified index. It supports additional keyword arguments for cursor-based pagination
+        and chunk size.
+
+        Args:
+            collection (Collection): The MongoDB collection from which documents are to be retrieved.
+            index_id (str): The identifier of the index to be used for retrieval.
+            **kwargs: Additional keyword arguments for retrieval.
+                - cursor (int, optional): The cursor position for pagination.
+                - chunk_size (int, optional): The number of documents to retrieve per chunk.
+
+        Returns:
+            tuple[int, list[dict[str, Any]]]: A tuple containing the cursor position and a list of
+            retrieved documents.
+
+        Raises:
+            ValueError: If the specified index does not exist in the collection.
+        """
         if MongoDBIndex(collection).index_exists(index_id):
-            cursor = kwargs.pop('cursor', None)
+            cursor: int | None = kwargs.pop('cursor', None)
             chunk_size = kwargs.pop('chunk_size', 500)
 
             try:
@@ -954,7 +1507,7 @@ class RedisMongoDB(AtomDB):
             if cursor is not None:
                 pymongo_cursor.skip(cursor).limit(chunk_size)
 
-                documents = [document for document in pymongo_cursor]
+                documents = list(pymongo_cursor)
 
                 if not documents:
                     return 0, []
@@ -964,11 +1517,11 @@ class RedisMongoDB(AtomDB):
                 else:
                     return cursor + chunk_size, documents
 
-            return 0, [document for document in pymongo_cursor]
+            return 0, list(pymongo_cursor)
         else:
             raise ValueError(f"Index '{index_id}' does not exist in collection '{collection}'")
 
-    def reindex(self, pattern_index_templates: Optional[Dict[str, Dict[str, Any]]] = None):
+    def reindex(self, pattern_index_templates: dict[str, dict[str, Any]] | None = None) -> None:
         if pattern_index_templates is not None:
             self.pattern_index_templates = deepcopy(pattern_index_templates)
         self.redis.flushall()
@@ -979,11 +1532,14 @@ class RedisMongoDB(AtomDB):
 
         mongo_filter = {FieldNames.ID_HASH: handle}
 
-        document = self.mongo_atoms_collection.find_one_and_delete(mongo_filter)
+        document: dict[str, Any] | None = self.mongo_atoms_collection.find_one_and_delete(
+            mongo_filter
+        )
 
         if not document:
             logger().error(
-                f'Failed to delete atom for handle: {handle}. This atom may not exist. - Details: {kwargs}'
+                f'Failed to delete atom for handle: {handle}. '
+                f'This atom may not exist. - Details: {kwargs}'
             )
             raise AtomDoesNotExist(
                 message='Nonexistent atom',
@@ -994,9 +1550,9 @@ class RedisMongoDB(AtomDB):
     def create_field_index(
         self,
         atom_type: str,
-        fields: List[str],
+        fields: list[str],
         named_type: Optional[str] = None,
-        composite_type: Optional[List[Any]] = None,
+        composite_type: Optional[list[Any]] = None,
         index_type: Optional[FieldIndexType] = None,
     ) -> str:
         if named_type and composite_type:
@@ -1022,8 +1578,8 @@ class RedisMongoDB(AtomDB):
             MongoIndexType.TEXT if index_type == FieldIndexType.TOKEN_INVERTED_LIST else None
         )
 
+        exc = ""
         try:
-            exc = ""
             index_id, index_props = MongoDBIndex(collection).create(
                 atom_type, fields, index_type=mongo_index_type, **kwargs
             )
@@ -1036,12 +1592,12 @@ class RedisMongoDB(AtomDB):
         except pymongo_errors.OperationFailure as e:
             exc = e
             logger().error(f"Error creating index in collection '{collection}': {str(e)}")
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-except
             exc = e
             logger().error(f"Error: {str(e)}")
         finally:
             if not index_id:
-                return (
+                return (  # pylint: disable=lost-exception
                     f"Index creation failed, Details: {str(exc)}"
                     if exc
                     else "Index creation failed"
@@ -1049,7 +1605,42 @@ class RedisMongoDB(AtomDB):
 
         return index_id
 
-    def _get_atoms_by_index(self, index_id: str, **kwargs) -> Union[Tuple[int, list], list]:
+    def _get_atoms_by_index(
+        self, index_id: str, **kwargs
+    ) -> tuple[  # TODO(angelo,andre): simplify this return type
+        int,
+        list[
+            dict[str, Any]
+            | tuple[
+                dict[str, Any],
+                list[
+                    dict[str, Any]
+                    | tuple[dict[str, Any], list[dict[str, Any]]]
+                    | tuple[dict[str, Any], list[tuple[dict[Any, Any], list[Any]]]]
+                ],
+            ]
+        ],
+    ]:
+        """
+        Retrieve atoms from the MongoDB collection using the specified index.
+
+        This method retrieves atoms from the MongoDB collection by utilizing the specified
+        index. It supports additional keyword arguments for cursor-based pagination and
+        chunk size.
+
+        Args:
+            index_id (str): The identifier of the index to be used for retrieval.
+            **kwargs: Additional keyword arguments for retrieval.
+                - cursor (int, optional): The cursor position for pagination.
+                - chunk_size (int, optional): The number of documents to retrieve per chunk.
+
+        Returns:
+            tuple[int, list[dict[str, Any] | tuple[dict[str, Any], list[dict[str, Any]]]]]:
+            A tuple containing the cursor position and a list of retrieved atoms.
+
+        Raises:
+            Exception: If there is an error retrieving atoms by index.
+        """
         try:
             documents = self._retrieve_documents_by_index(
                 self.mongo_atoms_collection, index_id, **kwargs
@@ -1060,21 +1651,32 @@ class RedisMongoDB(AtomDB):
             logger().error(f"Error retrieving atoms by index: {str(e)}")
             raise e
 
-    def retrieve_all_atoms(self) -> List[Dict[str, Any]]:
+    def retrieve_all_atoms(self) -> list[dict[str, Any]] | list[tuple[str, Any]]:
         try:
-            return [document for document in self.mongo_atoms_collection.find()]
+            return list(self.mongo_atoms_collection.find())
         except Exception as e:
             logger().error(f"Error retrieving all atoms: {str(e)}")
             raise e
 
-    def bulk_insert(self, documents: List[Dict[str, Any]]) -> None:
+    def bulk_insert(self, documents: list[dict[str, Any]]) -> None:
+        """
+        Insert multiple documents into the MongoDB collection and update indexes.
+
+        This method performs a bulk insert of the provided documents into the MongoDB collection.
+        It replaces existing documents with the same ID and updates the corresponding indexes.
+        Additional keyword arguments can be used to customize the insertion behavior.
+
+        Args:
+            documents (list[dict[str, Any]]): A list of documents to be inserted into the collection.
+
+        Raises:
+            pymongo.errors.BulkWriteError: If there is an error during the bulk write operation.
+            Exception: If there is an unexpected error during the insertion process.
+        """
         try:
             _id = FieldNames.ID_HASH
-            [
+            for document in documents:
                 self.mongo_atoms_collection.replace_one({_id: document[_id]}, document, upsert=True)
-                for document in documents
-            ]
             self._update_atom_indexes(documents)
-        except Exception:
-            logger().error("Error bulk inserting documents")
-            return None
+        except Exception as e:  # pylint: disable=broad-except
+            logger().error(f"Error bulk inserting documents: {str(e)}")

--- a/hyperon_das_atomdb/adapters/redis_mongo_db.py
+++ b/hyperon_das_atomdb/adapters/redis_mongo_db.py
@@ -99,12 +99,7 @@ class NodeDocuments:
         self.count = 0
 
     def add(self) -> None:
-        """
-        Increment the count of node documents managed by this instance.
-
-        Returns:
-            None
-        """
+        """Increment the count of node documents managed by this instance."""
         self.count += 1
 
     def get(self, handle: str, default_value: Any = None) -> Any:

--- a/hyperon_das_atomdb/adapters/redis_mongo_db.py
+++ b/hyperon_das_atomdb/adapters/redis_mongo_db.py
@@ -90,9 +90,6 @@ class NodeDocuments:
 
         Args:
             collection (Collection): The MongoDB collection to manage node documents.
-
-        Returns:
-            None
         """
         self.mongo_collection = collection
         self.cached_nodes = {}


### PR DESCRIPTION
Progress on ticket #161 

Refactors `redis_mongo_db.py`:
1. Applies `black` formatting.
2. Ensures lines width at max 100 chars.
3. Adds and/or fixes type annotations, mainly returns.
4. Applies new standard of type annotations (i.e. `dict[A, B] | None` instead of `Optional[Dict[A, B]]`).
5. Adds and/or fixes docstrings.
6. Ensures the file passes green through `pylint`.
7. Fixes some typos.
8. Left some `TODO` comments for future evaluation.
9. Eliminates a `while True` statement.