### PR TITLE
[#161] adding `mypy` to the repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ flake8:
 pylint:
 	@pylint ./hyperon_das_atomdb --rcfile=.pylintrc
 
+mypy:
+	@mypy --config-file mypy.ini ./hyperon_das_atomdb
+
 lint: isort black flake8
 
 unit-tests:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+ignore_missing_imports = true
+follow_imports = silent
+check_untyped_defs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+implicit_reexport = true
+show_error_context = true
+namespace_packages = true
+pretty = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ setuptools = "^70.2.0"
 [tool.poetry.group.dev.dependencies]
 flake8 = "^6.1.0"
 pylint = "^3.2.6"
+mypy = "^1.10.1"
 isort = "^5.12.0"
 black = "^23.7.0"
 pytest = "^7.4.2"


### PR DESCRIPTION
Progress on ticket #161 

Adds a new target to `Makefile`, named `mypy`.
For now, `make mypy` must be executed manually. Once all code base is passing green through `mypy`, it must be added to the CI pipeline as well as to the `Makefile`'s `pre-commit` target.