### PR TITLE
[#161] fixing some returns and type hints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ pylint:
 	@pylint ./hyperon_das_atomdb --rcfile=.pylintrc
 
 mypy:
-	@mypy --config-file mypy.ini ./hyperon_das_atomdb
+	@unbuffer mypy --color-output --config-file mypy.ini ./hyperon_das_atomdb
 
 lint: isort black flake8
 

--- a/hyperon_das_atomdb/adapters/redis_mongo_db.py
+++ b/hyperon_das_atomdb/adapters/redis_mongo_db.py
@@ -404,7 +404,11 @@ class RedisMongoDB(AtomDB):
 
         message = (
             f"Connecting to {redis_type} at "
-            + (f"{redis_username}:{redis_password}@" if redis_username and redis_password else "")
+            + (
+                f"{redis_username}:{len(redis_password)*'*'}@"
+                if redis_username and redis_password
+                else ""
+            )
             + f"{redis_hostname}:{redis_port}. ssl: {redis_ssl}"
         )
 

--- a/hyperon_das_atomdb/adapters/redis_mongo_db.py
+++ b/hyperon_das_atomdb/adapters/redis_mongo_db.py
@@ -403,9 +403,9 @@ class RedisMongoDB(AtomDB):
         redis_type = 'Redis cluster' if redis_cluster else 'Standalone Redis'
 
         message = (
-            f"Connecting to {redis_type} at " f"{redis_username}:{redis_password}@"
-            if redis_username and redis_password
-            else "" f"{redis_hostname}:{redis_port}. ssl: {redis_ssl}"
+            f"Connecting to {redis_type} at "
+            + (f"{redis_username}:{redis_password}@" if redis_username and redis_password else "")
+            + f"{redis_hostname}:{redis_port}. ssl: {redis_ssl}"
         )
 
         logger().info(message)

--- a/tests/unit/adapters/test_ram_only.py
+++ b/tests/unit/adapters/test_ram_only.py
@@ -1177,7 +1177,7 @@ class TestInMemoryDB:
         assert db.count_atoms() == {'atom_count': 3, 'node_count': 2, 'link_count': 1}
 
     def test_retrieve_all_atoms(self, database: InMemoryDB):
-        expected = list(database.db.node.items()) + list(database.db.link.items())
+        expected = list(database.db.node.values()) + list(database.db.link.values())
         actual = database.retrieve_all_atoms()
         assert expected == actual
 


### PR DESCRIPTION
Progress on ticket #161 

- Created some **Type Aliases**, like `AtomT: TypeAlias = dict[str, Any]`, similarly for `NodeT`, `NodeParamsT`, `LinkT` and `LinkParamsT`.
- Used the new type aliases for annotations on all over the code.
- Revisited and fixed all type hints with the help of `mypy`.
- Left some `TODO`s for future evaluation.
- Ensured that the entire repo passes green through `flake8` + `pylint` + `mypy`.
- Fixed a unit test.
- Improved docstrings.
