### PR TITLE
[#182] refactoring `AtomDB.get_atom`

### DIFF
--- a/hyperon_das_atomdb/adapters/ram_only.py
+++ b/hyperon_das_atomdb/adapters/ram_only.py
@@ -614,8 +614,8 @@ class InMemoryDB(AtomDB):
         self,
         index_id: str,
         query: list[OrderedDict[str, str]],
-        cursor: int | None = 0,
-        chunk_size: int | None = 500,
+        cursor: int = 0,
+        chunk_size: int = 500,
     ) -> tuple[int, list[AtomT]]:
         raise NotImplementedError()
 
@@ -627,7 +627,7 @@ class InMemoryDB(AtomDB):
     def get_node_by_name_starting_with(self, node_type: str, startswith: str) -> list[str]:
         raise NotImplementedError()
 
-    def _get_atom(self, handle: str, **kwargs) -> AtomT | None:
+    def _get_atom(self, handle: str) -> AtomT | None:
         return self.db.node.get(handle) or self._get_link(handle)
 
     def get_atom_type(self, handle: str) -> str | None:

--- a/hyperon_das_atomdb/adapters/ram_only.py
+++ b/hyperon_das_atomdb/adapters/ram_only.py
@@ -575,13 +575,11 @@ class InMemoryDB(AtomDB):
 
         return patterns_matched
 
-    def get_incoming_links(
-        self, atom_handle: str, **kwargs
-    ) -> tuple[int | None, list[IncomingLinksT]] | list[IncomingLinksT]:
+    def get_incoming_links(self, atom_handle: str, **kwargs) -> tuple[int | None, IncomingLinksT]:
         links = self.db.incoming_set.get(atom_handle, set())
         if kwargs.get("handles_only", False):
-            return list(links)
-        return [self.get_atom(handle, **kwargs) for handle in links]
+            return None, list(links)
+        return None, [self.get_atom(handle, **kwargs) for handle in links]
 
     def get_matched_type_template(
         self, template: list[Any], **kwargs
@@ -618,21 +616,7 @@ class InMemoryDB(AtomDB):
         query: list[OrderedDict[str, str]],
         cursor: int | None = 0,
         chunk_size: int | None = 500,
-    ) -> (  # TODO(angelo,andre): simplify this return type
-        list[str]
-        | tuple[
-            int,
-            list[dict[str, Any]]
-            | list[
-                tuple[
-                    dict[str, Any],
-                    list[dict[str, Any]]
-                    | list[tuple[dict[str, Any], list[dict[str, Any]]]]
-                    | list[tuple[dict[str, Any], list[tuple[dict[Any, Any], list[Any]]]]],
-                ]
-            ],
-        ]
-    ):
+    ) -> tuple[int, list[AtomT]]:
         raise NotImplementedError()
 
     def get_atoms_by_text_field(

--- a/hyperon_das_atomdb/adapters/ram_only.py
+++ b/hyperon_das_atomdb/adapters/ram_only.py
@@ -8,7 +8,6 @@ Classes:
     Database: A dataclass representing the structure of the in-memory database.
     InMemoryDB: A concrete implementation of the AtomDB interface using hashtables.
 """
-import re
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any, Iterable
@@ -644,27 +643,8 @@ class InMemoryDB(AtomDB):
     def get_node_by_name_starting_with(self, node_type: str, startswith: str) -> list[str]:
         raise NotImplementedError()
 
-    def get_atom(self, handle: str, **kwargs) -> AtomT:
-        document = self.db.node.get(handle) or self._get_link(handle)
-        if document:
-            answer: AtomT = {'handle': document['_id'], 'type': document['named_type']}
-            for key, value in document.items():
-                if key == '_id':
-                    continue
-                if re.search(AtomDB.key_pattern, key):
-                    answer.setdefault('targets', []).append(value)
-                else:
-                    answer[key] = value
-            return answer
-
-        logger().error(
-            f"Failed to retrieve atom for handle: {handle}. "
-            f"This link may not exist. - Details: {kwargs}"
-        )
-        raise AtomDoesNotExist(
-            message="Nonexistent atom",
-            details=f"handle: {handle}",
-        )
+    def _get_atom(self, handle: str, **kwargs) -> AtomT | None:
+        return self.db.node.get(handle) or self._get_link(handle)
 
     def get_atom_type(self, handle: str) -> str | None:
         atom = self.db.node.get(handle)

--- a/hyperon_das_atomdb/adapters/redis_mongo_db.py
+++ b/hyperon_das_atomdb/adapters/redis_mongo_db.py
@@ -10,7 +10,6 @@ for caching and fast access to frequently used data.
 import base64
 import collections
 import pickle
-import re
 import sys
 from copy import deepcopy
 from enum import Enum
@@ -855,27 +854,8 @@ class RedisMongoDB(AtomDB):
         # TODO(angelo): this is not good and it's needed due to all possible returns from get_atom
         return document[FieldNames.TYPE_NAME] if isinstance(document, dict) else None
 
-    def get_atom(self, handle: str, **kwargs) -> AtomT:
-        document = self._retrieve_document(handle)
-        if document:
-            answer: AtomT = {'handle': document['_id'], 'type': document['named_type']}
-            for key, value in document.items():
-                if key == '_id':
-                    continue
-                if re.search(AtomDB.key_pattern, key):
-                    answer.setdefault('targets', []).append(value)
-                else:
-                    answer[key] = value
-            return answer
-
-        logger().error(
-            f'Failed to retrieve atom for handle: {handle}.'
-            f'This link may not exist. - Details: {kwargs}'
-        )
-        raise AtomDoesNotExist(
-            message='Nonexistent atom',
-            details=f'handle: {handle}',
-        )
+    def _get_atom(self, handle: str, **kwargs) -> AtomT | None:
+        return self._retrieve_document(handle)
 
     def get_atom_type(self, handle: str) -> str | None:
         atom = self._retrieve_document(handle)

--- a/hyperon_das_atomdb/database.py
+++ b/hyperon_das_atomdb/database.py
@@ -625,23 +625,6 @@ class AtomDB(ABC):
             of link handles, or a list of matching link handles.
         """
 
-    @abstractmethod
-    def _get_atom(self, handle: str) -> AtomT | None:
-        """
-        Retrieve an atom by its handle.
-
-        Args:
-            handle (str): The handle of the atom to retrieve.
-
-        Returns:
-            AtomT | None: A dictionary representation of the atom if found, None otherwise.
-
-        Note:
-            This method is intended for internal use and should not be called directly.
-            It must be implemented by subclasses to provide a concrete way to retrieve atoms by
-            their handles.
-        """
-
     def get_atom(self, handle: str, **kwargs) -> AtomT:
         """
         Retrieve an atom by its handle.
@@ -676,6 +659,23 @@ class AtomDB(ABC):
             message='Nonexistent atom',
             details=f'handle: {handle}',
         )
+
+    @abstractmethod
+    def _get_atom(self, handle: str) -> AtomT | None:
+        """
+        Retrieve an atom by its handle.
+
+        Args:
+            handle (str): The handle of the atom to retrieve.
+
+        Returns:
+            AtomT | None: A dictionary representation of the atom if found, None otherwise.
+
+        Note:
+            This method is intended for internal use and should not be called directly.
+            It must be implemented by subclasses to provide a concrete way to retrieve atoms by
+            their handles.
+        """
 
     @abstractmethod
     def get_atom_type(self, handle: str) -> str | None:

--- a/hyperon_das_atomdb/database.py
+++ b/hyperon_das_atomdb/database.py
@@ -162,20 +162,6 @@ class AtomDB(ABC):
 
         return answer
 
-    # _recursive_link_split is not called anywhere in the code and
-    # self._recursive_link_handle is not defined in the class
-    # TODO(angelo,andre): remove this method or implement self._recursive_link_handle?
-    # def _recursive_link_split(self, params: dict[str, Any]) -> tuple[str, Any]:
-    #     name = params.get('name')
-    #     atom_type = params['type']
-    #     if name:
-    #         return self.node_handle(atom_type, name), atom_type
-    #     targets, composite_type = [
-    #         self._recursive_link_handle(target) for target in params['target']
-    #     ]
-    #     composite_type.insert(0, atom_type)
-    #     return self.link_handle(atom_type, targets), composite_type
-
     def _build_node(self, node_params: NodeParamsT) -> tuple[str, NodeT]:
         """
         Build a node with the specified parameters.
@@ -672,17 +658,7 @@ class AtomDB(ABC):
         """
 
     @abstractmethod
-    def get_atom(
-        self, handle: str, **kwargs
-    ) -> (
-        dict[str, Any]
-        | tuple[
-            dict[str, Any],
-            list[dict[str, Any]]
-            | list[tuple[dict[str, Any], list[dict[str, Any]]]]
-            | list[tuple[dict[str, Any], list[tuple[dict[Any, Any], list[Any]]]]],
-        ]  # TODO(angelo,andre): simplify this return type
-    ):
+    def get_atom(self, handle: str, **kwargs) -> AtomT:
         """
         Retrieve an atom by its handle.
 
@@ -691,10 +667,10 @@ class AtomDB(ABC):
             **kwargs: Additional arguments that may be used for filtering or other purposes.
 
         Returns:
-            dict[str, Any] | tuple[dict[str, Any], list[dict[str, Any]]] | tuple[dict[str, Any],
-            list[tuple[dict, list]]]: A dictionary representation of the atom, a tuple containing
-            the atom dictionary and a list of atom dictionaries, or a tuple containing the atom
-            dictionary and a list of tuples with atom dictionaries and lists.
+            AtomT: A dictionary representation of the atom.
+
+        Raises:
+            AtomDoesNotExist: If the atom with the specified handle does not exist.
         """
 
     @abstractmethod

--- a/hyperon_das_atomdb/database.py
+++ b/hyperon_das_atomdb/database.py
@@ -652,8 +652,8 @@ class AtomDB(ABC):
             return self._transform_to_target_format(document, **kwargs)
 
         logger().error(
-            f'Failed to retrieve atom for handle: {handle}.'
-            f'This link may not exist. - Details: {kwargs}'
+            f'Failed to retrieve atom for handle: {handle}. '
+            f'This atom does not exist. - Details: {kwargs}'
         )
         raise AtomDoesNotExist(
             message='Nonexistent atom',

--- a/tests/unit/adapters/test_ram_only.py
+++ b/tests/unit/adapters/test_ram_only.py
@@ -678,7 +678,7 @@ class TestInMemoryDB:
         assert exc.value.message == 'Nonexistent atom'
         assert exc.value.details == 'handle: test'
 
-    def test_get_atom_as_dist(self, database: InMemoryDB):
+    def test_get_atom_as_dict(self, database: InMemoryDB):
         h = database.get_node_handle('Concept', 'human')
         m = database.get_node_handle('Concept', 'monkey')
         s = database.get_link_handle('Similarity', [h, m])

--- a/tests/unit/adapters/test_ram_only.py
+++ b/tests/unit/adapters/test_ram_only.py
@@ -691,25 +691,30 @@ class TestInMemoryDB:
         m = database.get_node_handle('Concept', 'monkey')
         s = database.get_link_handle('Similarity', [h, m])
 
-        links = database.get_incoming_links(atom_handle=h, handles_only=False)
+        cursor, links = database.get_incoming_links(atom_handle=h, handles_only=False)
+        assert cursor is None
         atom = database.get_atom(handle=s)
         assert atom in links
 
-        links = database.get_incoming_links(
+        cursor, links = database.get_incoming_links(
             atom_handle=h, handles_only=False, targets_document=True
         )
-        for link, targets in links:
-            for a, b in zip(link['targets'], targets):
+        assert cursor is None
+        for link in links:
+            for a, b in zip(link['targets'], link['targets_document']):
                 assert a == b['handle']
 
-        links = database.get_incoming_links(atom_handle=h, handles_only=True)
+        cursor, links = database.get_incoming_links(atom_handle=h, handles_only=True)
+        assert cursor is None
         assert links == list(database.db.incoming_set.get(h))
         assert s in links
 
-        links = database.get_incoming_links(atom_handle=m, handles_only=True)
+        cursor, links = database.get_incoming_links(atom_handle=m, handles_only=True)
+        assert cursor is None
         assert links == list(database.db.incoming_set.get(m))
 
-        links = database.get_incoming_links(atom_handle=s, handles_only=True)
+        cursor, links = database.get_incoming_links(atom_handle=s, handles_only=True)
+        assert cursor is None
         assert links == []
 
     def test_get_atom_type(self, database: InMemoryDB):

--- a/tests/unit/adapters/test_redis_mongo_db.py
+++ b/tests/unit/adapters/test_redis_mongo_db.py
@@ -492,27 +492,39 @@ class TestRedisMongoDB:
         m = database.get_node_handle('Concept', 'monkey')
         s = database.get_link_handle('Similarity', [h, m])
 
-        links = database.get_incoming_links(atom_handle=h, handles_only=False)
+        cursor, links = database.get_incoming_links(atom_handle=h, handles_only=False)
+        assert cursor is None
         atom = database.get_atom(handle=s)
         assert atom in links
 
-        links = database.get_incoming_links(
+        cursor, links = database.get_incoming_links(
             atom_handle=h, handles_only=False, targets_document=True
         )
-        for link, targets in links:
-            for a, b in zip(link['targets'], targets):
+        assert cursor is None
+        assert len(links) > 0
+        assert all(isinstance(link, dict) for link in links)
+        for link in links:
+            for a, b in zip(link['targets'], link['targets_document']):
                 assert a == b['handle']
 
-        links = database.get_incoming_links(atom_handle=h, handles_only=True)
+        cursor, links = database.get_incoming_links(atom_handle=h, handles_only=True)
+        assert cursor is None
+        assert len(links) > 0
+        assert all(isinstance(link, str) for link in links)
         answer = database.redis.smembers(f'incoming_set:{h}')
-        assert links == [h for h in answer]
+        assert links == list(answer)
         assert s in links
 
-        links = database.get_incoming_links(atom_handle=m, handles_only=True)
+        cursor, links = database.get_incoming_links(atom_handle=m, handles_only=True)
+        assert cursor is None
+        assert len(links) > 0
+        assert all(isinstance(link, str) for link in links)
         answer = database.redis.smembers(f'incoming_set:{m}')
-        assert links == [h for h in answer]
+        assert links == list(answer)
 
-        links = database.get_incoming_links(atom_handle=s, handles_only=True)
+        cursor, links = database.get_incoming_links(atom_handle=s, handles_only=True)
+        assert cursor is None
+        assert len(links) == 0
         assert links == []
 
     def test_get_atom_type(self, database: RedisMongoDB):


### PR DESCRIPTION
Closes #182 

- Refactored the `AtomDB.get_atom` method and all code related to it, for example, the `get_incoming_links` method.
  - Now, when both `no_target_format` is set to `False`and `targets_document` is set to `True` in `kwargs`, the `targets_document` will be included in the Atom dictionary as a sub-object instead of giving a different return type (`tuple`) as it was previously implemented.
- Revisited some type annotations and docstrings.
- Adapted unit tests which involve `get_atom`.