### PR TITLE
[#185] refactoring `AtomDB.get_matched_links` and related code

### DIFF
--- a/hyperon_das_atomdb/adapters/ram_only.py
+++ b/hyperon_das_atomdb/adapters/ram_only.py
@@ -22,10 +22,11 @@ from hyperon_das_atomdb.database import (
     IncomingLinksT,
     LinkParamsT,
     LinkT,
+    MatchedLinksResultT,
     MatchedTargetsListT,
+    MatchedTypesResultT,
     NodeParamsT,
     NodeT,
-    PatternMatchingResultT,
 )
 from hyperon_das_atomdb.exceptions import AtomDoesNotExist, InvalidOperationException
 from hyperon_das_atomdb.logger import logger
@@ -537,7 +538,7 @@ class InMemoryDB(AtomDB):
 
     def get_matched_links(
         self, link_type: str, target_handles: list[str], **kwargs
-    ) -> PatternMatchingResultT:
+    ) -> MatchedLinksResultT:
         if link_type != WILDCARD and WILDCARD not in target_handles:
             link_handle = self.get_link_handle(link_type, target_handles)
             return None, [link_handle]
@@ -572,9 +573,7 @@ class InMemoryDB(AtomDB):
             return None, list(links)
         return None, [self.get_atom(handle, **kwargs) for handle in links]
 
-    def get_matched_type_template(
-        self, template: list[Any], **kwargs
-    ) -> tuple[int | None, list[tuple[str, tuple[str, ...]]]]:
+    def get_matched_type_template(self, template: list[Any], **kwargs) -> MatchedTypesResultT:
         hash_base = self._build_named_type_hash_template(template)
         template_hash = ExpressionHasher.composite_hash(hash_base)
         templates_matched = list(self.db.templates.get(template_hash, set()))
@@ -582,9 +581,7 @@ class InMemoryDB(AtomDB):
             return None, self._filter_non_toplevel(templates_matched)
         return None, templates_matched
 
-    def get_matched_type(
-        self, link_type: str, **kwargs
-    ) -> tuple[int | None, list[tuple[str, tuple[str, ...]]]]:
+    def get_matched_type(self, link_type: str, **kwargs) -> MatchedTypesResultT:
         link_type_hash = ExpressionHasher.named_type_hash(link_type)
         templates_matched = list(self.db.templates.get(link_type_hash, set()))
         if kwargs.get("toplevel_only"):

--- a/hyperon_das_atomdb/adapters/ram_only.py
+++ b/hyperon_das_atomdb/adapters/ram_only.py
@@ -331,10 +331,12 @@ class InMemoryDB(AtomDB):
         Returns:
             MatchedTargetsListT: A list of matches that are toplevel only.
         """
+        if self.db.link is None:
+            return []
         return [
             (link_handle, matched_targets)
             for link_handle, matched_targets in matches
-            if (link := self.db.link) and link[link_handle][FieldNames.IS_TOPLEVEL]
+            if self.db.link.get(link_handle, dict()).get(FieldNames.IS_TOPLEVEL)
         ]
 
     @staticmethod

--- a/hyperon_das_atomdb/adapters/ram_only.py
+++ b/hyperon_das_atomdb/adapters/ram_only.py
@@ -331,12 +331,12 @@ class InMemoryDB(AtomDB):
         Returns:
             MatchedTargetsListT: A list of matches that are toplevel only.
         """
-        if self.db.link is None:
-            return []
+        if not self.db.link:
+            return matches
         return [
             (link_handle, matched_targets)
             for link_handle, matched_targets in matches
-            if self.db.link.get(link_handle, dict()).get(FieldNames.IS_TOPLEVEL)
+            if (link := self.db.link.get(link_handle)) and link.get(FieldNames.IS_TOPLEVEL)
         ]
 
     @staticmethod

--- a/hyperon_das_atomdb/adapters/ram_only.py
+++ b/hyperon_das_atomdb/adapters/ram_only.py
@@ -22,8 +22,10 @@ from hyperon_das_atomdb.database import (
     IncomingLinksT,
     LinkParamsT,
     LinkT,
+    MatchedTargetsListT,
     NodeParamsT,
     NodeT,
+    PatternMatchingResultT,
 )
 from hyperon_das_atomdb.exceptions import AtomDoesNotExist, InvalidOperationException
 from hyperon_das_atomdb.logger import logger
@@ -317,27 +319,22 @@ class InMemoryDB(AtomDB):
         if link_document is not None:
             self._update_index(atom=link_document, delete_atom=True)
 
-    def _filter_non_toplevel(
-        self, matches: list[tuple[str, tuple[str, ...]]]
-    ) -> list[tuple[str, tuple[str, ...]]]:
+    def _filter_non_toplevel(self, matches: MatchedTargetsListT) -> MatchedTargetsListT:
         """
         Filter out non-toplevel matches from the provided list.
 
         Args:
-            matches (list[tuple[str, tuple[str, ...]]]): A list of matches, where each match is a
-                tuple containing a link handle and a tuple of target handles.
+            matches (MatchedTargetsListT): A list of matches, where each match is a tuple
+            containing a link handle and a tuple of target handles.
 
         Returns:
-            list[tuple[str, tuple[str, ...]]]: A list of matches that are toplevel only.
+            MatchedTargetsListT: A list of matches that are toplevel only.
         """
-        matches_toplevel_only: list[tuple[str, tuple[str, ...]]] = []
-        if len(matches) > 0:
-            for match in matches:
-                link_handle = match[0]
-                links = self.db.link
-                if links[link_handle][FieldNames.IS_TOPLEVEL]:
-                    matches_toplevel_only.append(match)
-        return matches_toplevel_only
+        return [
+            (link_handle, matched_targets)
+            for link_handle, matched_targets in matches
+            if (link := self.db.link) and link[link_handle][FieldNames.IS_TOPLEVEL]
+        ]
 
     @staticmethod
     def _build_targets_list(link: dict[str, Any]) -> list[Any]:
@@ -483,12 +480,12 @@ class InMemoryDB(AtomDB):
             if value[FieldNames.COMPOSITE_TYPE_HASH] == node_type_hash
         ]
 
-    def get_all_links(self, link_type: str, **kwargs) -> list[str]:
+    def get_all_links(self, link_type: str, **kwargs) -> tuple[int | None, list[str]]:
         answer = []
         for _, link in self.db.link.items():
             if link[FieldNames.TYPE_NAME] == link_type:
                 answer.append(link[FieldNames.ID_HASH])
-        return answer
+        return None, answer
 
     def get_link_handle(self, link_type: str, target_handles: list[str]) -> str:
         link_handle = self.link_handle(link_type, target_handles)
@@ -540,16 +537,10 @@ class InMemoryDB(AtomDB):
 
     def get_matched_links(
         self, link_type: str, target_handles: list[str], **kwargs
-    ) -> (
-        list[str]
-        | list[list[str]]
-        | list[tuple[str, tuple[str, ...]]]
-        | tuple[int, list[str]]
-        | tuple[int, list[list[str]]]  # TODO(angelo): simplify this return type
-    ):
+    ) -> PatternMatchingResultT:
         if link_type != WILDCARD and WILDCARD not in target_handles:
             link_handle = self.get_link_handle(link_type, target_handles)
-            return [link_handle]
+            return None, [link_handle]
 
         if link_type == WILDCARD:
             link_type_hash = WILDCARD
@@ -571,9 +562,9 @@ class InMemoryDB(AtomDB):
         patterns_matched = list(self.db.patterns.get(pattern_hash, set()))
 
         if kwargs.get("toplevel_only"):
-            return self._filter_non_toplevel(patterns_matched)
+            return None, self._filter_non_toplevel(patterns_matched)
 
-        return patterns_matched
+        return None, patterns_matched
 
     def get_incoming_links(self, atom_handle: str, **kwargs) -> tuple[int | None, IncomingLinksT]:
         links = self.db.incoming_set.get(atom_handle, set())
@@ -583,29 +574,22 @@ class InMemoryDB(AtomDB):
 
     def get_matched_type_template(
         self, template: list[Any], **kwargs
-    ) -> (
-        list[list[str]]
-        | tuple[int, list[list[str]]]
-        | list[tuple[str, tuple[str, ...]]]  # TODO(angelo): simplify this return type
-    ):
+    ) -> tuple[int | None, list[tuple[str, tuple[str, ...]]]]:
         hash_base = self._build_named_type_hash_template(template)
         template_hash = ExpressionHasher.composite_hash(hash_base)
         templates_matched = list(self.db.templates.get(template_hash, set()))
         if kwargs.get("toplevel_only"):
-            return self._filter_non_toplevel(templates_matched)
-        return templates_matched
+            return None, self._filter_non_toplevel(templates_matched)
+        return None, templates_matched
 
     def get_matched_type(
         self, link_type: str, **kwargs
-    ) -> (
-        list[list[str]]
-        | list[tuple[str, tuple[str, ...]]]  # TODO(angelo): simplify this return type
-    ):
+    ) -> tuple[int | None, list[tuple[str, tuple[str, ...]]]]:
         link_type_hash = ExpressionHasher.named_type_hash(link_type)
         templates_matched = list(self.db.templates.get(link_type_hash, set()))
         if kwargs.get("toplevel_only"):
-            return self._filter_non_toplevel(templates_matched)
-        return templates_matched
+            return None, self._filter_non_toplevel(templates_matched)
+        return None, templates_matched
 
     def get_atoms_by_field(self, query: list[OrderedDict[str, str]]) -> list[str]:
         raise NotImplementedError()

--- a/hyperon_das_atomdb/adapters/redis_mongo_db.py
+++ b/hyperon_das_atomdb/adapters/redis_mongo_db.py
@@ -579,7 +579,7 @@ class RedisMongoDB(AtomDB):
         return [
             (link_handle, matched_targets)
             for link_handle, matched_targets in matches
-            if (link := self._retrieve_document(link_handle)) and link[FieldNames.IS_TOPLEVEL]
+            if (link := self._retrieve_document(link_handle)) and link.get(FieldNames.IS_TOPLEVEL)
         ]
 
     def get_node_handle(self, node_type: str, node_name: str) -> str:

--- a/hyperon_das_atomdb/adapters/redis_mongo_db.py
+++ b/hyperon_das_atomdb/adapters/redis_mongo_db.py
@@ -755,13 +755,7 @@ class RedisMongoDB(AtomDB):
             except AtomDoesNotExist:
                 return None, []
 
-        if link_type == WILDCARD:
-            link_type_hash = WILDCARD
-        else:
-            link_type_hash = self._get_atom_type_hash(link_type)
-
-        if link_type_hash is None:
-            return None, []
+        link_type_hash = WILDCARD if link_type == WILDCARD else self._get_atom_type_hash(link_type)
 
         if link_type in UNORDERED_LINK_TYPES:
             target_handles = sorted(target_handles)

--- a/hyperon_das_atomdb/database.py
+++ b/hyperon_das_atomdb/database.py
@@ -45,6 +45,14 @@ LinkParamsT: TypeAlias = LinkT  # pylint: disable=invalid-name
 
 IncomingLinksT: TypeAlias = list[str] | list[AtomT]  # pylint: disable=invalid-name
 
+MatchedTargetsListT: TypeAlias = list[tuple[str, tuple[str, ...]]]  # pylint: disable=invalid-name
+
+HandlesListT: TypeAlias = list[str]  # pylint: disable=invalid-name
+
+PatternMatchingResultT: TypeAlias = tuple[
+    int | None, HandlesListT | MatchedTargetsListT
+]  # pylint: disable=invalid-name
+
 
 class FieldNames(str, Enum):
     """Enumeration of field names used in the AtomDB."""
@@ -474,7 +482,7 @@ class AtomDB(ABC):
         """
 
     @abstractmethod
-    def get_all_links(self, link_type: str, **kwargs) -> list[str] | tuple[int, list[str]]:
+    def get_all_links(self, link_type: str, **kwargs) -> tuple[int | None, list[str]]:
         """
         Get all links of a specific type.
 
@@ -483,8 +491,8 @@ class AtomDB(ABC):
             **kwargs: Additional arguments that may be used for filtering or other purposes.
 
         Returns:
-            list[str] | tuple[int, list[str]]: A list of link handles or a tuple containing an
-            integer and a list of link handles.
+            tuple[int | None, list[str]]: tuple containing a cursor (which can be None if cursor is
+                not applicable) and a list of link handles.
         """
 
     @abstractmethod
@@ -553,13 +561,7 @@ class AtomDB(ABC):
     @abstractmethod
     def get_matched_links(
         self, link_type: str, target_handles: list[str], **kwargs
-    ) -> (
-        list[str]
-        | list[list[str]]
-        | list[tuple[str, tuple[str, ...]]]
-        | tuple[int, list[str]]
-        | tuple[int, list[list[str]]]  # TODO(angelo): simplify this return type
-    ):
+    ) -> PatternMatchingResultT:
         """
         Retrieve links that match a specified link type and target handles.
 
@@ -570,22 +572,14 @@ class AtomDB(ABC):
                 purposes.
 
         Returns:
-            list[str] | list[list[str]] | list[tuple[str, tuple[str, ...]]] |
-            tuple[int, list[str]] | tuple[int, list[list[str]]]: A list of matching
-            link handles, a list of lists of matching link handles, a list of
-            tuples containing link handles and their targets, or a tuple containing
-            an integer and a list of matching link handles or lists of matching
-            link handles.
+            PatternMatchingResultT: tuple containing a cursor (which can be None if cursor is not
+            applicable) and a list of matching link handles.
         """
 
     @abstractmethod
     def get_matched_type_template(
         self, template: list[Any], **kwargs
-    ) -> (
-        list[list[str]]
-        | tuple[int, list[list[str]]]
-        | list[tuple[str, tuple[str, ...]]]  # TODO(angelo): simplify this return type
-    ):
+    ) -> tuple[int | None, list[tuple[str, tuple[str, ...]]]]:
         """
         Retrieve links that match a specified type template.
 
@@ -595,21 +589,14 @@ class AtomDB(ABC):
                 purposes.
 
         Returns:
-            list[tuple[str, tuple[str, ...]]] | tuple[int, list[str | list[str]] |
-            list[str]: A list of tuples containing link handles and their
-            targets, a tuple containing an integer and a list of link handles or lists
-            of link handles, or a list of matching link handles.
+            tuple[int | None, list[tuple[str, tuple[str, ...]]]]: tuple containing a cursor (which
+            can be None if cursor is not applicable) and a list of matching link handles.
         """
 
     @abstractmethod
     def get_matched_type(
         self, link_type: str, **kwargs
-    ) -> (
-        list[str]
-        | list[list[str]]
-        | list[tuple[str, tuple[str, ...]]]
-        | tuple[int, list[str] | list[list[str]]]  # TODO(angelo): simplify this return type
-    ):
+    ) -> tuple[int | None, list[tuple[str, tuple[str, ...]]]]:
         """
         Retrieve links that match a specified link type.
 
@@ -619,10 +606,8 @@ class AtomDB(ABC):
                 purposes.
 
         Returns:
-            list[tuple[str, tuple[str, ...]]] | tuple[int, list[str | list[str]] |
-            list[str]: A list of tuples containing link handles and their
-            targets, a tuple containing an integer and a list of link handles or lists
-            of link handles, or a list of matching link handles.
+            tuple[int | None, list[tuple[str, tuple[str, ...]]]]: tuple containing a cursor (which
+            can be None if cursor is not applicable) and a list of matching link handles.
         """
 
     def get_atom(self, handle: str, **kwargs) -> AtomT:

--- a/hyperon_das_atomdb/database.py
+++ b/hyperon_das_atomdb/database.py
@@ -33,29 +33,29 @@ from hyperon_das_atomdb.utils.expression_hasher import ExpressionHasher
 WILDCARD = '*'
 UNORDERED_LINK_TYPES: list[Any] = []
 
-AtomT: TypeAlias = dict[str, Any]  # pylint: disable=invalid-name
+# pylint: disable=invalid-name
 
-NodeT: TypeAlias = AtomT  # pylint: disable=invalid-name
+AtomT: TypeAlias = dict[str, Any]
 
-NodeParamsT: TypeAlias = NodeT  # pylint: disable=invalid-name
+NodeT: TypeAlias = AtomT
 
-LinkT: TypeAlias = AtomT  # pylint: disable=invalid-name
+NodeParamsT: TypeAlias = NodeT
 
-LinkParamsT: TypeAlias = LinkT  # pylint: disable=invalid-name
+LinkT: TypeAlias = AtomT
 
-IncomingLinksT: TypeAlias = list[str] | list[AtomT]  # pylint: disable=invalid-name
+LinkParamsT: TypeAlias = LinkT
 
-MatchedTargetsListT: TypeAlias = list[tuple[str, tuple[str, ...]]]  # pylint: disable=invalid-name
+IncomingLinksT: TypeAlias = list[str] | list[AtomT]
 
-HandlesListT: TypeAlias = list[str]  # pylint: disable=invalid-name
+MatchedTargetsListT: TypeAlias = list[tuple[str, tuple[str, ...]]]
 
-MatchedLinksResultT: TypeAlias = tuple[
-    int | None, HandlesListT | MatchedTargetsListT
-]  # pylint: disable=invalid-name
+HandlesListT: TypeAlias = list[str]
 
-MatchedTypesResultT: TypeAlias = tuple[
-    int | None, MatchedTargetsListT
-]  # pylint: disable=invalid-name
+MatchedLinksResultT: TypeAlias = tuple[int | None, HandlesListT | MatchedTargetsListT]
+
+MatchedTypesResultT: TypeAlias = tuple[int | None, MatchedTargetsListT]
+
+# pylint: enable=invalid-name
 
 
 class FieldNames(str, Enum):

--- a/hyperon_das_atomdb/database.py
+++ b/hyperon_das_atomdb/database.py
@@ -576,7 +576,7 @@ class AtomDB(ABC):
                 purposes.
 
         Returns:
-            PatternMatchingResultT: tuple containing a cursor (which can be None if cursor is not
+            MatchedLinksResultT: tuple containing a cursor (which can be None if cursor is not
             applicable) and a list of matching link handles.
         """
 

--- a/hyperon_das_atomdb/database.py
+++ b/hyperon_das_atomdb/database.py
@@ -49,8 +49,12 @@ MatchedTargetsListT: TypeAlias = list[tuple[str, tuple[str, ...]]]  # pylint: di
 
 HandlesListT: TypeAlias = list[str]  # pylint: disable=invalid-name
 
-PatternMatchingResultT: TypeAlias = tuple[
+MatchedLinksResultT: TypeAlias = tuple[
     int | None, HandlesListT | MatchedTargetsListT
+]  # pylint: disable=invalid-name
+
+MatchedTypesResultT: TypeAlias = tuple[
+    int | None, MatchedTargetsListT
 ]  # pylint: disable=invalid-name
 
 
@@ -561,7 +565,7 @@ class AtomDB(ABC):
     @abstractmethod
     def get_matched_links(
         self, link_type: str, target_handles: list[str], **kwargs
-    ) -> PatternMatchingResultT:
+    ) -> MatchedLinksResultT:
         """
         Retrieve links that match a specified link type and target handles.
 
@@ -577,9 +581,7 @@ class AtomDB(ABC):
         """
 
     @abstractmethod
-    def get_matched_type_template(
-        self, template: list[Any], **kwargs
-    ) -> tuple[int | None, list[tuple[str, tuple[str, ...]]]]:
+    def get_matched_type_template(self, template: list[Any], **kwargs) -> MatchedTypesResultT:
         """
         Retrieve links that match a specified type template.
 
@@ -589,14 +591,12 @@ class AtomDB(ABC):
                 purposes.
 
         Returns:
-            tuple[int | None, list[tuple[str, tuple[str, ...]]]]: tuple containing a cursor (which
-            can be None if cursor is not applicable) and a list of matching link handles.
+            MatchedTypesResultT: tuple containing a cursor (which can be None if cursor is not
+            applicable) and a list of matching link handles.
         """
 
     @abstractmethod
-    def get_matched_type(
-        self, link_type: str, **kwargs
-    ) -> tuple[int | None, list[tuple[str, tuple[str, ...]]]]:
+    def get_matched_type(self, link_type: str, **kwargs) -> MatchedTypesResultT:
         """
         Retrieve links that match a specified link type.
 
@@ -606,8 +606,8 @@ class AtomDB(ABC):
                 purposes.
 
         Returns:
-            tuple[int | None, list[tuple[str, tuple[str, ...]]]]: tuple containing a cursor (which
-            can be None if cursor is not applicable) and a list of matching link handles.
+            MatchedTypesResultT: tuple containing a cursor (which can be None if cursor is not
+            applicable) and a list of matching link handles.
         """
 
     def get_atom(self, handle: str, **kwargs) -> AtomT:

--- a/tests/integration/adapters/test_redis_mongo.py
+++ b/tests/integration/adapters/test_redis_mongo.py
@@ -54,46 +54,32 @@ class TestRedisMongo:
         return db
 
     def _check_basic_patterns(self, db, toplevel_only=False):
-        assert sorted(
-            [
-                answer[1]
-                for answer in db.get_matched_links(
-                    "Inheritance",
-                    [WILDCARD, db.node_handle("Concept", "mammal")],
-                    toplevel_only=toplevel_only,
-                )
-            ]
-        ) == sorted([human, monkey, chimp, rhino])
-        assert sorted(
-            [
-                answer[2]
-                for answer in db.get_matched_links(
-                    "Inheritance",
-                    [db.node_handle("Concept", "mammal"), WILDCARD],
-                    toplevel_only=toplevel_only,
-                )
-            ]
-        ) == sorted([animal])
-        assert sorted(
-            [
-                answer[1]
-                for answer in db.get_matched_links(
-                    "Similarity",
-                    [WILDCARD, db.node_handle("Concept", "human")],
-                    toplevel_only=toplevel_only,
-                )
-            ]
-        ) == sorted([monkey, chimp, ent])
-        assert sorted(
-            [
-                answer[2]
-                for answer in db.get_matched_links(
-                    "Similarity",
-                    [db.node_handle("Concept", "human"), WILDCARD],
-                    toplevel_only=toplevel_only,
-                )
-            ]
-        ) == sorted([monkey, chimp, ent])
+        cursors = [-1] * 4
+        cursors[0], answers = db.get_matched_links(
+            "Inheritance",
+            [WILDCARD, db.node_handle("Concept", "mammal")],
+            toplevel_only=toplevel_only,
+        )
+        assert sorted([answer[1][0] for answer in answers]) == sorted([human, monkey, chimp, rhino])
+        cursors[1], answers = db.get_matched_links(
+            "Inheritance",
+            [db.node_handle("Concept", "mammal"), WILDCARD],
+            toplevel_only=toplevel_only,
+        )
+        assert sorted([answer[1][1] for answer in answers]) == sorted([animal])
+        cursors[2], answers = db.get_matched_links(
+            "Similarity",
+            [WILDCARD, db.node_handle("Concept", "human")],
+            toplevel_only=toplevel_only,
+        )
+        assert sorted([answer[1][0] for answer in answers]) == sorted([monkey, chimp, ent])
+        cursors[3], answers = db.get_matched_links(
+            "Similarity",
+            [db.node_handle("Concept", "human"), WILDCARD],
+            toplevel_only=toplevel_only,
+        )
+        assert sorted([answer[1][1] for answer in answers]) == sorted([monkey, chimp, ent])
+        assert all(c is None for c in cursors), f'{cursors=}'
 
     def test_redis_retrieve(self, _cleanup, _db: RedisMongoDB):
         db = _db
@@ -108,7 +94,8 @@ class TestRedisMongo:
         }
         assert db._retrieve_name(human) == "human"
 
-        _, links = db._retrieve_incoming_set(mammal)
+        cursor, links = db._retrieve_incoming_set(mammal)
+        assert cursor is None
         assert len(links) == 5
         for link in links:
             outgoing = db._retrieve_outgoing_set(link)
@@ -120,103 +107,149 @@ class TestRedisMongo:
                 [mammal, animal],
             ]
 
-        _, templates = db._retrieve_template("41c082428b28d7e9ea96160f7fd614ad")
+        cursor, templates = db._retrieve_template("41c082428b28d7e9ea96160f7fd614ad")
+        assert cursor is None
         assert len(templates) == 12
-        assert tuple(
-            [
-                "116df61c01859c710d178ba14a483509",
-                tuple(["c1db9b517073e51eb7ef6fed608ec204", "b99ae727c787f1b13b452fd4c9ce1b9a"]),
-            ]
+        assert (
+            tuple(
+                [
+                    "116df61c01859c710d178ba14a483509",
+                    tuple(["c1db9b517073e51eb7ef6fed608ec204", "b99ae727c787f1b13b452fd4c9ce1b9a"]),
+                ]
+            )
+            in templates
         )
-        assert tuple(
-            [
-                "1c3bf151ea200b2d9e088a1178d060cb",
-                tuple(["bdfe4e7a431f73386f37c6448afe5840", "0a32b476852eeb954979b87f5f6cb7af"]),
-            ]
+        assert (
+            tuple(
+                [
+                    "1c3bf151ea200b2d9e088a1178d060cb",
+                    tuple(["bdfe4e7a431f73386f37c6448afe5840", "0a32b476852eeb954979b87f5f6cb7af"]),
+                ]
+            )
+            in templates
         )
-        assert tuple(
-            [
-                "4120e428ab0fa162a04328e5217912ff",
-                tuple(["bb34ce95f161a6b37ff54b3d4c817857", "0a32b476852eeb954979b87f5f6cb7af"]),
-            ]
+        assert (
+            tuple(
+                [
+                    "4120e428ab0fa162a04328e5217912ff",
+                    tuple(["bb34ce95f161a6b37ff54b3d4c817857", "0a32b476852eeb954979b87f5f6cb7af"]),
+                ]
+            )
+            in templates
         )
-        assert tuple(
-            [
-                "75756335011dcedb71a0d9a7bd2da9e8",
-                tuple(["5b34c54bee150c04f9fa584b899dc030", "bdfe4e7a431f73386f37c6448afe5840"]),
-            ]
+        assert (
+            tuple(
+                [
+                    "75756335011dcedb71a0d9a7bd2da9e8",
+                    tuple(["5b34c54bee150c04f9fa584b899dc030", "bdfe4e7a431f73386f37c6448afe5840"]),
+                ]
+            )
+            in templates
         )
-        assert tuple(
-            [
-                "906fa505ae3bc6336d80a5f9aaa47b3b",
-                tuple(["d03e59654221c1e8fcda404fd5c8d6cb", "08126b066d32ee37743e255a2558cccd"]),
-            ]
+        assert (
+            tuple(
+                [
+                    "906fa505ae3bc6336d80a5f9aaa47b3b",
+                    tuple(["d03e59654221c1e8fcda404fd5c8d6cb", "08126b066d32ee37743e255a2558cccd"]),
+                ]
+            )
+            in templates
         )
-        assert tuple(
-            [
-                "959924e3aab197af80a84c1ab261fd65",
-                tuple(["08126b066d32ee37743e255a2558cccd", "b99ae727c787f1b13b452fd4c9ce1b9a"]),
-            ]
+        assert (
+            tuple(
+                [
+                    "959924e3aab197af80a84c1ab261fd65",
+                    tuple(["08126b066d32ee37743e255a2558cccd", "b99ae727c787f1b13b452fd4c9ce1b9a"]),
+                ]
+            )
+            in templates
         )
-        assert tuple(
-            [
-                "b0f428929706d1d991e4d712ad08f9ab",
-                tuple(["b99ae727c787f1b13b452fd4c9ce1b9a", "0a32b476852eeb954979b87f5f6cb7af"]),
-            ]
+        assert (
+            tuple(
+                [
+                    "b0f428929706d1d991e4d712ad08f9ab",
+                    tuple(["b99ae727c787f1b13b452fd4c9ce1b9a", "0a32b476852eeb954979b87f5f6cb7af"]),
+                ]
+            )
+            in templates
         )
-        assert tuple(
-            [
-                "c93e1e758c53912638438e2a7d7f7b7f",
-                tuple(["af12f10f9ae2002a1607ba0b47ba8407", "bdfe4e7a431f73386f37c6448afe5840"]),
-            ]
+        assert (
+            tuple(
+                [
+                    "c93e1e758c53912638438e2a7d7f7b7f",
+                    tuple(["af12f10f9ae2002a1607ba0b47ba8407", "bdfe4e7a431f73386f37c6448afe5840"]),
+                ]
+            )
+            in templates
         )
-        assert tuple(
-            [
-                "e4685d56969398253b6f77efd21dc347",
-                tuple(["b94941d8cd1c0ee4ad3dd3dcab52b964", "80aff30094874e75028033a38ce677bb"]),
-            ]
+        assert (
+            tuple(
+                [
+                    "e4685d56969398253b6f77efd21dc347",
+                    tuple(["b94941d8cd1c0ee4ad3dd3dcab52b964", "80aff30094874e75028033a38ce677bb"]),
+                ]
+            )
+            in templates
         )
-        assert tuple(
-            [
-                "ee1c03e6d1f104ccd811cfbba018451a",
-                tuple(["4e8e26e3276af8a5c2ac2cc2dc95c6d2", "80aff30094874e75028033a38ce677bb"]),
-            ]
+        assert (
+            tuple(
+                [
+                    "ee1c03e6d1f104ccd811cfbba018451a",
+                    tuple(["4e8e26e3276af8a5c2ac2cc2dc95c6d2", "80aff30094874e75028033a38ce677bb"]),
+                ]
+            )
+            in templates
         )
-        assert tuple(
-            [
-                "f31dfe97db782e8cec26de18dddf8965",
-                tuple(["1cdffc6b0b89ff41d68bec237481d1e1", "bdfe4e7a431f73386f37c6448afe5840"]),
-            ]
+        assert (
+            tuple(
+                [
+                    "f31dfe97db782e8cec26de18dddf8965",
+                    tuple(["1cdffc6b0b89ff41d68bec237481d1e1", "bdfe4e7a431f73386f37c6448afe5840"]),
+                ]
+            )
+            in templates
         )
-        assert tuple(
-            [
-                "fbf03d17d6a40feff828a3f2c6e86f05",
-                tuple(["99d18c702e813b07260baf577c60c455", "bdfe4e7a431f73386f37c6448afe5840"]),
-            ]
+        assert (
+            tuple(
+                [
+                    "fbf03d17d6a40feff828a3f2c6e86f05",
+                    tuple(["99d18c702e813b07260baf577c60c455", "bdfe4e7a431f73386f37c6448afe5840"]),
+                ]
+            )
+            in templates
         )
 
-        _, patterns = db._retrieve_pattern("112002ff70ea491aad735f978e9d95f5")
+        cursor, patterns = db._retrieve_pattern("112002ff70ea491aad735f978e9d95f5")
+        assert cursor is None
         assert len(patterns) == 4
-        assert [
+        assert (
             "75756335011dcedb71a0d9a7bd2da9e8",
-            "5b34c54bee150c04f9fa584b899dc030",
-            "bdfe4e7a431f73386f37c6448afe5840",
-        ] in patterns
-        assert [
+            (
+                "5b34c54bee150c04f9fa584b899dc030",
+                "bdfe4e7a431f73386f37c6448afe5840",
+            ),
+        ) in patterns
+        assert (
             "fbf03d17d6a40feff828a3f2c6e86f05",
-            "99d18c702e813b07260baf577c60c455",
-            "bdfe4e7a431f73386f37c6448afe5840",
-        ] in patterns
-        assert [
+            (
+                "99d18c702e813b07260baf577c60c455",
+                "bdfe4e7a431f73386f37c6448afe5840",
+            ),
+        ) in patterns
+        assert (
             "f31dfe97db782e8cec26de18dddf8965",
-            "1cdffc6b0b89ff41d68bec237481d1e1",
-            "bdfe4e7a431f73386f37c6448afe5840",
-        ] in patterns
-        assert [
+            (
+                "1cdffc6b0b89ff41d68bec237481d1e1",
+                "bdfe4e7a431f73386f37c6448afe5840",
+            ),
+        ) in patterns
+        assert (
             "c93e1e758c53912638438e2a7d7f7b7f",
-            "af12f10f9ae2002a1607ba0b47ba8407",
-            "bdfe4e7a431f73386f37c6448afe5840",
-        ] in patterns
+            (
+                "af12f10f9ae2002a1607ba0b47ba8407",
+                "bdfe4e7a431f73386f37c6448afe5840",
+            ),
+        ) in patterns
 
     def test_patterns(self, _cleanup, _db: RedisMongoDB):
         db = _db
@@ -232,14 +265,11 @@ class TestRedisMongo:
         assert db.count_atoms() == {'atom_count': 0}
         db.commit()
         assert db.count_atoms() == {'atom_count': 40}
-        assert sorted(
-            [
-                answer[1]
-                for answer in db.get_matched_links(
-                    "Inheritance", [WILDCARD, db.node_handle("Concept", "mammal")]
-                )
-            ]
-        ) == sorted([human, monkey, chimp, rhino])
+        cursor, answers = db.get_matched_links(
+            "Inheritance", [WILDCARD, db.node_handle("Concept", "mammal")]
+        )
+        assert cursor is None
+        assert sorted([answer[1][0] for answer in answers]) == sorted([human, monkey, chimp, rhino])
         assert db.get_atom(human)["name"] == node_docs[human]["name"]
         link_pre = db.get_atom(inheritance[human][mammal])
         assert "strength" not in link_pre
@@ -273,14 +303,13 @@ class TestRedisMongo:
         new_link_handle = db.get_link_handle("Inheritance", [dog, mammal])
         new_link = db.get_atom(new_link_handle)
         assert db.get_link_targets(new_link_handle) == new_link["targets"]
-        assert sorted(
-            [
-                answer[1]
-                for answer in db.get_matched_links(
-                    "Inheritance", [WILDCARD, db.node_handle("Concept", "mammal")]
-                )
-            ]
-        ) == sorted([human, monkey, chimp, rhino, dog])
+        cursor, answers = db.get_matched_links(
+            "Inheritance", [WILDCARD, db.node_handle("Concept", "mammal")]
+        )
+        assert cursor is None
+        assert sorted([answer[1][0] for answer in answers]) == sorted(
+            [human, monkey, chimp, rhino, dog]
+        )
 
     def test_reindex(self, _cleanup, _db: RedisMongoDB):
         db = _db
@@ -361,14 +390,14 @@ class TestRedisMongo:
             )
             assert sorted(db._retrieve_template('e40489cd1e7102e35469c937e05c8bba')[1]) == sorted(
                 [
-                    [inheritance_dog_mammal_handle, dog_handle, mammal_handle],
-                    [inheritance_cat_mammal_handle, cat_handle, mammal_handle],
+                    (inheritance_dog_mammal_handle, (dog_handle, mammal_handle)),
+                    (inheritance_cat_mammal_handle, (cat_handle, mammal_handle)),
                 ]
             )
             assert sorted(db._retrieve_template('41c082428b28d7e9ea96160f7fd614ad')[1]) == sorted(
                 [
-                    [inheritance_dog_mammal_handle, dog_handle, mammal_handle],
-                    [inheritance_cat_mammal_handle, cat_handle, mammal_handle],
+                    (inheritance_dog_mammal_handle, (dog_handle, mammal_handle)),
+                    (inheritance_cat_mammal_handle, (cat_handle, mammal_handle)),
                 ]
             )
 
@@ -387,51 +416,51 @@ class TestRedisMongo:
 
             assert sorted(db._retrieve_pattern('112002ff70ea491aad735f978e9d95f5')[1]) == sorted(
                 [
-                    [inheritance_dog_mammal_handle, dog_handle, mammal_handle],
-                    [inheritance_cat_mammal_handle, cat_handle, mammal_handle],
+                    (inheritance_dog_mammal_handle, (dog_handle, mammal_handle)),
+                    (inheritance_cat_mammal_handle, (cat_handle, mammal_handle)),
                 ]
             )
             assert sorted(db._retrieve_pattern('6e644e70a9fe3145c88b5b6261af5754')[1]) == sorted(
                 [
-                    [inheritance_dog_mammal_handle, dog_handle, mammal_handle],
-                    [inheritance_cat_mammal_handle, cat_handle, mammal_handle],
+                    (inheritance_dog_mammal_handle, (dog_handle, mammal_handle)),
+                    (inheritance_cat_mammal_handle, (cat_handle, mammal_handle)),
                 ]
             )
             assert sorted(db._retrieve_pattern('5dd515aa7a451276feac4f8b9d84ae91')[1]) == sorted(
                 [
-                    [inheritance_dog_mammal_handle, dog_handle, mammal_handle],
-                    [inheritance_cat_mammal_handle, cat_handle, mammal_handle],
+                    (inheritance_dog_mammal_handle, (dog_handle, mammal_handle)),
+                    (inheritance_cat_mammal_handle, (cat_handle, mammal_handle)),
                 ]
             )
             assert sorted(db._retrieve_pattern('7ead6cfa03894c62761162b7603aa885')[1]) == sorted(
                 [
-                    [inheritance_dog_mammal_handle, dog_handle, mammal_handle],
-                    [inheritance_cat_mammal_handle, cat_handle, mammal_handle],
+                    (inheritance_dog_mammal_handle, (dog_handle, mammal_handle)),
+                    (inheritance_cat_mammal_handle, (cat_handle, mammal_handle)),
                 ]
             )
             assert db._retrieve_pattern('e55007a8477a4e6bf4fec76e4ffd7e10')[1] == [
-                [inheritance_dog_mammal_handle, dog_handle, mammal_handle]
+                (inheritance_dog_mammal_handle, (dog_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('23dc149b3218d166a14730db55249126')[1] == [
-                [inheritance_dog_mammal_handle, dog_handle, mammal_handle]
+                (inheritance_dog_mammal_handle, (dog_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('399751d7319f9061d97cd1d75728b66b')[1] == [
-                [inheritance_dog_mammal_handle, dog_handle, mammal_handle]
+                (inheritance_dog_mammal_handle, (dog_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('d0eaae6eaf750e821b26642cef32becf')[1] == [
-                [inheritance_dog_mammal_handle, dog_handle, mammal_handle]
+                (inheritance_dog_mammal_handle, (dog_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('f29daafee640d91aa7091e44551fc74a')[1] == [
-                [inheritance_cat_mammal_handle, cat_handle, mammal_handle]
+                (inheritance_cat_mammal_handle, (cat_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('a11d7cbf62bc544f75702b5fb6a514ff')[1] == [
-                [inheritance_cat_mammal_handle, cat_handle, mammal_handle]
+                (inheritance_cat_mammal_handle, (cat_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('3ba42d45a50c89600d92fb3f1a46c1b5')[1] == [
-                [inheritance_cat_mammal_handle, cat_handle, mammal_handle]
+                (inheritance_cat_mammal_handle, (cat_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('9fb71ffef74a1a98eb0bfce7aa3d54e3')[1] == [
-                [inheritance_cat_mammal_handle, cat_handle, mammal_handle]
+                (inheritance_cat_mammal_handle, (cat_handle, mammal_handle))
             ]
 
         def _check_asserts_2():
@@ -501,34 +530,34 @@ class TestRedisMongo:
                 [dog_handle, mammal_handle]
             )
             assert db._retrieve_template('e40489cd1e7102e35469c937e05c8bba')[1] == [
-                [inheritance_dog_mammal_handle, dog_handle, mammal_handle]
+                (inheritance_dog_mammal_handle, (dog_handle, mammal_handle))
             ]
             assert db._retrieve_template('41c082428b28d7e9ea96160f7fd614ad')[1] == [
-                [inheritance_dog_mammal_handle, dog_handle, mammal_handle]
+                (inheritance_dog_mammal_handle, (dog_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('112002ff70ea491aad735f978e9d95f5')[1] == [
-                [inheritance_dog_mammal_handle, dog_handle, mammal_handle],
+                (inheritance_dog_mammal_handle, (dog_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('6e644e70a9fe3145c88b5b6261af5754')[1] == [
-                [inheritance_dog_mammal_handle, dog_handle, mammal_handle],
+                (inheritance_dog_mammal_handle, (dog_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('5dd515aa7a451276feac4f8b9d84ae91')[1] == [
-                [inheritance_dog_mammal_handle, dog_handle, mammal_handle],
+                (inheritance_dog_mammal_handle, (dog_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('7ead6cfa03894c62761162b7603aa885')[1] == [
-                [inheritance_dog_mammal_handle, dog_handle, mammal_handle],
+                (inheritance_dog_mammal_handle, (dog_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('e55007a8477a4e6bf4fec76e4ffd7e10')[1] == [
-                [inheritance_dog_mammal_handle, dog_handle, mammal_handle]
+                (inheritance_dog_mammal_handle, (dog_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('23dc149b3218d166a14730db55249126')[1] == [
-                [inheritance_dog_mammal_handle, dog_handle, mammal_handle]
+                (inheritance_dog_mammal_handle, (dog_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('399751d7319f9061d97cd1d75728b66b')[1] == [
-                [inheritance_dog_mammal_handle, dog_handle, mammal_handle]
+                (inheritance_dog_mammal_handle, (dog_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('d0eaae6eaf750e821b26642cef32becf')[1] == [
-                [inheritance_dog_mammal_handle, dog_handle, mammal_handle]
+                (inheritance_dog_mammal_handle, (dog_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('f29daafee640d91aa7091e44551fc74a')[1] == []
             assert db._retrieve_pattern('a11d7cbf62bc544f75702b5fb6a514ff')[1] == []
@@ -552,38 +581,38 @@ class TestRedisMongo:
             )
             assert db._retrieve_outgoing_set(inheritance_dog_mammal_handle) == []
             assert db._retrieve_template('e40489cd1e7102e35469c937e05c8bba')[1] == [
-                [inheritance_cat_mammal_handle, cat_handle, mammal_handle]
+                (inheritance_cat_mammal_handle, (cat_handle, mammal_handle))
             ]
             assert db._retrieve_template('41c082428b28d7e9ea96160f7fd614ad')[1] == [
-                [inheritance_cat_mammal_handle, cat_handle, mammal_handle]
+                (inheritance_cat_mammal_handle, (cat_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('112002ff70ea491aad735f978e9d95f5')[1] == [
-                [inheritance_cat_mammal_handle, cat_handle, mammal_handle]
+                (inheritance_cat_mammal_handle, (cat_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('6e644e70a9fe3145c88b5b6261af5754')[1] == [
-                [inheritance_cat_mammal_handle, cat_handle, mammal_handle]
+                (inheritance_cat_mammal_handle, (cat_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('5dd515aa7a451276feac4f8b9d84ae91')[1] == [
-                [inheritance_cat_mammal_handle, cat_handle, mammal_handle]
+                (inheritance_cat_mammal_handle, (cat_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('7ead6cfa03894c62761162b7603aa885')[1] == [
-                [inheritance_cat_mammal_handle, cat_handle, mammal_handle]
+                (inheritance_cat_mammal_handle, (cat_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('e55007a8477a4e6bf4fec76e4ffd7e10')[1] == []
             assert db._retrieve_pattern('23dc149b3218d166a14730db55249126')[1] == []
             assert db._retrieve_pattern('399751d7319f9061d97cd1d75728b66b')[1] == []
             assert db._retrieve_pattern('d0eaae6eaf750e821b26642cef32becf')[1] == []
             assert db._retrieve_pattern('f29daafee640d91aa7091e44551fc74a')[1] == [
-                [inheritance_cat_mammal_handle, cat_handle, mammal_handle]
+                (inheritance_cat_mammal_handle, (cat_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('a11d7cbf62bc544f75702b5fb6a514ff')[1] == [
-                [inheritance_cat_mammal_handle, cat_handle, mammal_handle]
+                (inheritance_cat_mammal_handle, (cat_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('3ba42d45a50c89600d92fb3f1a46c1b5')[1] == [
-                [inheritance_cat_mammal_handle, cat_handle, mammal_handle]
+                (inheritance_cat_mammal_handle, (cat_handle, mammal_handle))
             ]
             assert db._retrieve_pattern('9fb71ffef74a1a98eb0bfce7aa3d54e3')[1] == [
-                [inheritance_cat_mammal_handle, cat_handle, mammal_handle]
+                (inheritance_cat_mammal_handle, (cat_handle, mammal_handle))
             ]
 
         db = _db
@@ -706,166 +735,148 @@ class TestRedisMongo:
         db.commit()
 
         response = db.get_matched_links('Similarity', [human, monkey], cursor=0)
-        assert response == (0, [AtomDB.link_handle('Similarity', [human, monkey])])
+        assert response == (None, [AtomDB.link_handle('Similarity', [human, monkey])])
 
         response = db.get_matched_links('Fake', [human, monkey], cursor=0)
-        assert response == (0, [])
+        assert response == (None, [])
 
-        response = db.get_matched_links('Similarity', [human, '*'], cursor=0)
-        assert (response[0], sorted(response[1])) == (
+        cursor, response = db.get_matched_links('Similarity', [human, '*'], cursor=0)
+        assert (cursor, sorted(response)) == (
             0,
             [
-                [
+                (
                     '16f7e407087bfa0b35b13d13a1aadcae',
-                    'af12f10f9ae2002a1607ba0b47ba8407',
-                    '4e8e26e3276af8a5c2ac2cc2dc95c6d2',
-                ],
-                [
+                    (
+                        'af12f10f9ae2002a1607ba0b47ba8407',
+                        '4e8e26e3276af8a5c2ac2cc2dc95c6d2',
+                    ),
+                ),
+                (
                     'b5459e299a5c5e8662c427f7e01b3bf1',
-                    'af12f10f9ae2002a1607ba0b47ba8407',
-                    '5b34c54bee150c04f9fa584b899dc030',
-                ],
-                [
+                    (
+                        'af12f10f9ae2002a1607ba0b47ba8407',
+                        '5b34c54bee150c04f9fa584b899dc030',
+                    ),
+                ),
+                (
                     'bad7472f41a0e7d601ca294eb4607c3a',
-                    'af12f10f9ae2002a1607ba0b47ba8407',
-                    '1cdffc6b0b89ff41d68bec237481d1e1',
-                ],
+                    (
+                        'af12f10f9ae2002a1607ba0b47ba8407',
+                        '1cdffc6b0b89ff41d68bec237481d1e1',
+                    ),
+                ),
             ],
         )
 
         template = ['Inheritance', 'Concept', 'Concept']
 
-        response = db.get_matched_type_template(template, cursor=0)
-        assert (response[0], sorted(response[1])) == (
+        cursor, response = db.get_matched_type_template(template, cursor=0)
+        assert (cursor, sorted(response)) == (
             0,
             [
-                [
+                (
                     '116df61c01859c710d178ba14a483509',
-                    'c1db9b517073e51eb7ef6fed608ec204',
-                    'b99ae727c787f1b13b452fd4c9ce1b9a',
-                ],
-                [
+                    ('c1db9b517073e51eb7ef6fed608ec204', 'b99ae727c787f1b13b452fd4c9ce1b9a'),
+                ),
+                (
                     '1c3bf151ea200b2d9e088a1178d060cb',
-                    'bdfe4e7a431f73386f37c6448afe5840',
-                    '0a32b476852eeb954979b87f5f6cb7af',
-                ],
-                [
+                    ('bdfe4e7a431f73386f37c6448afe5840', '0a32b476852eeb954979b87f5f6cb7af'),
+                ),
+                (
                     '4120e428ab0fa162a04328e5217912ff',
-                    'bb34ce95f161a6b37ff54b3d4c817857',
-                    '0a32b476852eeb954979b87f5f6cb7af',
-                ],
-                [
+                    ('bb34ce95f161a6b37ff54b3d4c817857', '0a32b476852eeb954979b87f5f6cb7af'),
+                ),
+                (
                     '75756335011dcedb71a0d9a7bd2da9e8',
-                    '5b34c54bee150c04f9fa584b899dc030',
-                    'bdfe4e7a431f73386f37c6448afe5840',
-                ],
-                [
+                    ('5b34c54bee150c04f9fa584b899dc030', 'bdfe4e7a431f73386f37c6448afe5840'),
+                ),
+                (
                     '906fa505ae3bc6336d80a5f9aaa47b3b',
-                    'd03e59654221c1e8fcda404fd5c8d6cb',
-                    '08126b066d32ee37743e255a2558cccd',
-                ],
-                [
+                    ('d03e59654221c1e8fcda404fd5c8d6cb', '08126b066d32ee37743e255a2558cccd'),
+                ),
+                (
                     '959924e3aab197af80a84c1ab261fd65',
-                    '08126b066d32ee37743e255a2558cccd',
-                    'b99ae727c787f1b13b452fd4c9ce1b9a',
-                ],
-                [
+                    ('08126b066d32ee37743e255a2558cccd', 'b99ae727c787f1b13b452fd4c9ce1b9a'),
+                ),
+                (
                     'b0f428929706d1d991e4d712ad08f9ab',
-                    'b99ae727c787f1b13b452fd4c9ce1b9a',
-                    '0a32b476852eeb954979b87f5f6cb7af',
-                ],
-                [
+                    ('b99ae727c787f1b13b452fd4c9ce1b9a', '0a32b476852eeb954979b87f5f6cb7af'),
+                ),
+                (
                     'c93e1e758c53912638438e2a7d7f7b7f',
-                    'af12f10f9ae2002a1607ba0b47ba8407',
-                    'bdfe4e7a431f73386f37c6448afe5840',
-                ],
-                [
+                    ('af12f10f9ae2002a1607ba0b47ba8407', 'bdfe4e7a431f73386f37c6448afe5840'),
+                ),
+                (
                     'e4685d56969398253b6f77efd21dc347',
-                    'b94941d8cd1c0ee4ad3dd3dcab52b964',
-                    '80aff30094874e75028033a38ce677bb',
-                ],
-                [
+                    ('b94941d8cd1c0ee4ad3dd3dcab52b964', '80aff30094874e75028033a38ce677bb'),
+                ),
+                (
                     'ee1c03e6d1f104ccd811cfbba018451a',
-                    '4e8e26e3276af8a5c2ac2cc2dc95c6d2',
-                    '80aff30094874e75028033a38ce677bb',
-                ],
-                [
+                    ('4e8e26e3276af8a5c2ac2cc2dc95c6d2', '80aff30094874e75028033a38ce677bb'),
+                ),
+                (
                     'f31dfe97db782e8cec26de18dddf8965',
-                    '1cdffc6b0b89ff41d68bec237481d1e1',
-                    'bdfe4e7a431f73386f37c6448afe5840',
-                ],
-                [
+                    ('1cdffc6b0b89ff41d68bec237481d1e1', 'bdfe4e7a431f73386f37c6448afe5840'),
+                ),
+                (
                     'fbf03d17d6a40feff828a3f2c6e86f05',
-                    '99d18c702e813b07260baf577c60c455',
-                    'bdfe4e7a431f73386f37c6448afe5840',
-                ],
+                    ('99d18c702e813b07260baf577c60c455', 'bdfe4e7a431f73386f37c6448afe5840'),
+                ),
             ],
         )
 
-        response = db.get_matched_type('Inheritance', cursor=0)
-        assert (response[0], sorted(response[1])) == (
+        cursor, response = db.get_matched_type('Inheritance', cursor=0)
+        assert (cursor, sorted(response)) == (
             0,
             [
-                [
+                (
                     '116df61c01859c710d178ba14a483509',
-                    'c1db9b517073e51eb7ef6fed608ec204',
-                    'b99ae727c787f1b13b452fd4c9ce1b9a',
-                ],
-                [
+                    ('c1db9b517073e51eb7ef6fed608ec204', 'b99ae727c787f1b13b452fd4c9ce1b9a'),
+                ),
+                (
                     '1c3bf151ea200b2d9e088a1178d060cb',
-                    'bdfe4e7a431f73386f37c6448afe5840',
-                    '0a32b476852eeb954979b87f5f6cb7af',
-                ],
-                [
+                    ('bdfe4e7a431f73386f37c6448afe5840', '0a32b476852eeb954979b87f5f6cb7af'),
+                ),
+                (
                     '4120e428ab0fa162a04328e5217912ff',
-                    'bb34ce95f161a6b37ff54b3d4c817857',
-                    '0a32b476852eeb954979b87f5f6cb7af',
-                ],
-                [
+                    ('bb34ce95f161a6b37ff54b3d4c817857', '0a32b476852eeb954979b87f5f6cb7af'),
+                ),
+                (
                     '75756335011dcedb71a0d9a7bd2da9e8',
-                    '5b34c54bee150c04f9fa584b899dc030',
-                    'bdfe4e7a431f73386f37c6448afe5840',
-                ],
-                [
+                    ('5b34c54bee150c04f9fa584b899dc030', 'bdfe4e7a431f73386f37c6448afe5840'),
+                ),
+                (
                     '906fa505ae3bc6336d80a5f9aaa47b3b',
-                    'd03e59654221c1e8fcda404fd5c8d6cb',
-                    '08126b066d32ee37743e255a2558cccd',
-                ],
-                [
+                    ('d03e59654221c1e8fcda404fd5c8d6cb', '08126b066d32ee37743e255a2558cccd'),
+                ),
+                (
                     '959924e3aab197af80a84c1ab261fd65',
-                    '08126b066d32ee37743e255a2558cccd',
-                    'b99ae727c787f1b13b452fd4c9ce1b9a',
-                ],
-                [
+                    ('08126b066d32ee37743e255a2558cccd', 'b99ae727c787f1b13b452fd4c9ce1b9a'),
+                ),
+                (
                     'b0f428929706d1d991e4d712ad08f9ab',
-                    'b99ae727c787f1b13b452fd4c9ce1b9a',
-                    '0a32b476852eeb954979b87f5f6cb7af',
-                ],
-                [
+                    ('b99ae727c787f1b13b452fd4c9ce1b9a', '0a32b476852eeb954979b87f5f6cb7af'),
+                ),
+                (
                     'c93e1e758c53912638438e2a7d7f7b7f',
-                    'af12f10f9ae2002a1607ba0b47ba8407',
-                    'bdfe4e7a431f73386f37c6448afe5840',
-                ],
-                [
+                    ('af12f10f9ae2002a1607ba0b47ba8407', 'bdfe4e7a431f73386f37c6448afe5840'),
+                ),
+                (
                     'e4685d56969398253b6f77efd21dc347',
-                    'b94941d8cd1c0ee4ad3dd3dcab52b964',
-                    '80aff30094874e75028033a38ce677bb',
-                ],
-                [
+                    ('b94941d8cd1c0ee4ad3dd3dcab52b964', '80aff30094874e75028033a38ce677bb'),
+                ),
+                (
                     'ee1c03e6d1f104ccd811cfbba018451a',
-                    '4e8e26e3276af8a5c2ac2cc2dc95c6d2',
-                    '80aff30094874e75028033a38ce677bb',
-                ],
-                [
+                    ('4e8e26e3276af8a5c2ac2cc2dc95c6d2', '80aff30094874e75028033a38ce677bb'),
+                ),
+                (
                     'f31dfe97db782e8cec26de18dddf8965',
-                    '1cdffc6b0b89ff41d68bec237481d1e1',
-                    'bdfe4e7a431f73386f37c6448afe5840',
-                ],
-                [
+                    ('1cdffc6b0b89ff41d68bec237481d1e1', 'bdfe4e7a431f73386f37c6448afe5840'),
+                ),
+                (
                     'fbf03d17d6a40feff828a3f2c6e86f05',
-                    '99d18c702e813b07260baf577c60c455',
-                    'bdfe4e7a431f73386f37c6448afe5840',
-                ],
+                    ('99d18c702e813b07260baf577c60c455', 'bdfe4e7a431f73386f37c6448afe5840'),
+                ),
             ],
         )
 
@@ -1158,10 +1169,12 @@ class TestRedisMongo:
         db.bulk_insert(documents)
 
         assert db.count_atoms() == {'atom_count': 3}
-        assert db.get_matched_links('Similarity', ['node1', 'node2']) == [
-            db.link_handle('Similarity', ['node1', 'node2'])
-        ]
-        _, similarity = db.get_all_links('Similarity')
+        assert db.get_matched_links('Similarity', ['node1', 'node2']) == (
+            None,
+            [db.link_handle('Similarity', ['node1', 'node2'])],
+        )
+        cursor, similarity = db.get_all_links('Similarity')
+        assert cursor == 0
         assert similarity == [db.link_handle('Similarity', ['node1', 'node2'])]
         assert db.get_all_nodes('Concept') == ['node1', 'node2']
 
@@ -1170,8 +1183,10 @@ class TestRedisMongo:
         self._add_atoms(db)
         db.commit()
         response = db.retrieve_all_atoms()
-        _, inheritance = db.get_all_links('Inheritance')
-        _, similarity = db.get_all_links('Similarity')
+        cursors = [-1] * 2
+        cursors[0], inheritance = db.get_all_links('Inheritance')
+        cursors[1], similarity = db.get_all_links('Similarity')
+        assert all(c == 0 for c in cursors), f'{cursors=}'
         links = inheritance + similarity
         nodes = db.get_all_nodes('Concept')
         assert len(response) == len(links) + len(nodes)


### PR DESCRIPTION
Closes #185

Refactored `AtomDB.get_matched_links` method and related code in order to simplify return types, as well as other methods with similar return types.
