### PR TITLE
[#191] adding skipped test for future evaluation

### DIFF
--- a/hyperon_das_atomdb/utils/expression_hasher.py
+++ b/hyperon_das_atomdb/utils/expression_hasher.py
@@ -108,11 +108,7 @@ class ExpressionHasher:
                 return hash_base[0]
             else:
                 return ExpressionHasher._compute_hash(
-                    ExpressionHasher.compound_separator.join(
-                        ExpressionHasher.composite_hash(hash_base)
-                        if isinstance(hash_base, list)
-                        else hash_base
-                    )
+                    ExpressionHasher.compound_separator.join(hash_base)
                 )
         else:
             raise ValueError(

--- a/hyperon_das_atomdb/utils/expression_hasher.py
+++ b/hyperon_das_atomdb/utils/expression_hasher.py
@@ -108,7 +108,11 @@ class ExpressionHasher:
                 return hash_base[0]
             else:
                 return ExpressionHasher._compute_hash(
-                    ExpressionHasher.compound_separator.join(hash_base)
+                    ExpressionHasher.compound_separator.join(
+                        ExpressionHasher.composite_hash(hash_base)
+                        if isinstance(hash_base, list)
+                        else hash_base
+                    )
                 )
         else:
             raise ValueError(

--- a/tests/unit/adapters/test_ram_only.py
+++ b/tests/unit/adapters/test_ram_only.py
@@ -473,17 +473,17 @@ class TestInMemoryDB:
         assert cursor is None
         assert len(actual) == 2
 
-    # @pytest.mark.skip(
-    #     reason=(
-    #         "get_matched_links does not support nested lists in the target_handles parameter. "
-    #         "See: https://github.com/singnet/das-atom-db/issues/191"
-    #     )
-    # )
+    @pytest.mark.skip(
+        reason=(
+            "get_matched_links does not support nested lists in the target_handles parameter. "
+            "See: https://github.com/singnet/das-atom-db/issues/191"
+        )
+    )
     def test_get_matched_links_nested_lists(self, database: InMemoryDB):
         chimp = ExpressionHasher.terminal_hash('Concept', 'chimp')
         human = ExpressionHasher.terminal_hash('Concept', 'human')
         monkey = ExpressionHasher.terminal_hash('Concept', 'monkey')
-        nearness_chimp_human = database.add_link(
+        database.add_link(
             {
                 'type': 'Nearness',
                 'targets': [
@@ -493,7 +493,7 @@ class TestInMemoryDB:
             }
         )
         nearness_chimp_human_handle = database.get_link_handle('Nearness', [chimp, human])
-        nearness_chimp_monkey = database.add_link(
+        database.add_link(
             {
                 'type': 'Nearness',
                 'targets': [
@@ -503,7 +503,7 @@ class TestInMemoryDB:
             }
         )
         nearness_chimp_monkey_handle = database.get_link_handle('Nearness', [chimp, monkey])
-        connectivity = database.add_link(
+        database.add_link(
             {
                 'type': 'Connectivity',
                 'targets': [
@@ -524,20 +524,11 @@ class TestInMemoryDB:
                 ],
             }
         )
-        connectivity_handle = database.get_link_handle(
-            'Connectivity', [nearness_chimp_human_handle, nearness_chimp_monkey_handle]
-        )
         target_handles = [
-            connectivity_handle,
             [nearness_chimp_human_handle, nearness_chimp_monkey_handle],
         ]
-        links = database.get_matched_links('Connectivity', target_handles, toplevel=False)
-        # raise AssertionError(
-        #     f'{connectivity=}\n'
-        #     f'{nearness_chimp_human=}\n'
-        #     f'{nearness_chimp_monkey=}\n'
-        #     f'{links=}\n'
-        # )
+        links = database.get_matched_links('Connectivity', target_handles)
+        assert len(links) == 1
 
     def test_get_all_nodes(self, database):
         ret = database.get_all_nodes('Concept')

--- a/tests/unit/adapters/test_ram_only.py
+++ b/tests/unit/adapters/test_ram_only.py
@@ -211,39 +211,6 @@ class TestInMemoryDB:
                     {'type': 'Concept', 'name': 'human'},
                 ],
             },
-            {
-                'type': 'Nearness',
-                'targets': [
-                    {'type': 'Concept', 'name': 'chimp'},
-                    {'type': 'Concept', 'name': 'human'},
-                ],
-            },
-            {
-                'type': 'Nearness',
-                'targets': [
-                    {'type': 'Concept', 'name': 'chimp'},
-                    {'type': 'Concept', 'name': 'monkey'},
-                ],
-            },
-            {
-                'type': 'Connectivity',
-                'targets': [
-                    {
-                        'type': 'Nearness',
-                        'targets': [
-                            {'type': 'Concept', 'name': 'chimp'},
-                            {'type': 'Concept', 'name': 'human'},
-                        ],
-                    },
-                    {
-                        'type': 'Nearness',
-                        'targets': [
-                            {'type': 'Concept', 'name': 'chimp'},
-                            {'type': 'Concept', 'name': 'monkey'},
-                        ],
-                    },
-                ],
-            },
         ]
 
     @pytest.fixture()

--- a/tests/unit/adapters/test_ram_only.py
+++ b/tests/unit/adapters/test_ram_only.py
@@ -447,29 +447,6 @@ class TestInMemoryDB:
         )
     )
     def test_get_matched_links_nested_lists(self, database: InMemoryDB):
-        chimp = ExpressionHasher.terminal_hash('Concept', 'chimp')
-        human = ExpressionHasher.terminal_hash('Concept', 'human')
-        monkey = ExpressionHasher.terminal_hash('Concept', 'monkey')
-        database.add_link(
-            {
-                'type': 'Nearness',
-                'targets': [
-                    {'type': 'Concept', 'name': 'chimp'},
-                    {'type': 'Concept', 'name': 'human'},
-                ],
-            }
-        )
-        nearness_chimp_human_handle = database.get_link_handle('Nearness', [chimp, human])
-        database.add_link(
-            {
-                'type': 'Nearness',
-                'targets': [
-                    {'type': 'Concept', 'name': 'chimp'},
-                    {'type': 'Concept', 'name': 'monkey'},
-                ],
-            }
-        )
-        nearness_chimp_monkey_handle = database.get_link_handle('Nearness', [chimp, monkey])
         database.add_link(
             {
                 'type': 'Connectivity',
@@ -491,10 +468,19 @@ class TestInMemoryDB:
                 ],
             }
         )
-        target_handles = [
+        chimp = ExpressionHasher.terminal_hash('Concept', 'chimp')
+        human = ExpressionHasher.terminal_hash('Concept', 'human')
+        monkey = ExpressionHasher.terminal_hash('Concept', 'monkey')
+        assert database.link_exists('Nearness', [chimp, human])
+        assert database.link_exists('Nearness', [chimp, monkey])
+        nearness_chimp_human_handle = database.get_link_handle('Nearness', [chimp, human])
+        nearness_chimp_monkey_handle = database.get_link_handle('Nearness', [chimp, monkey])
+        assert database.link_exists(
+            'Connectivity',
             [nearness_chimp_human_handle, nearness_chimp_monkey_handle],
-        ]
-        links = database.get_matched_links('Connectivity', target_handles)
+        )
+        target_handles = [[chimp, human], [chimp, monkey]]
+        _, links = database.get_matched_links('Connectivity', target_handles)
         assert len(links) == 1
 
     def test_get_all_nodes(self, database):

--- a/tests/unit/adapters/test_ram_only.py
+++ b/tests/unit/adapters/test_ram_only.py
@@ -211,6 +211,39 @@ class TestInMemoryDB:
                     {'type': 'Concept', 'name': 'human'},
                 ],
             },
+            {
+                'type': 'Nearness',
+                'targets': [
+                    {'type': 'Concept', 'name': 'chimp'},
+                    {'type': 'Concept', 'name': 'human'},
+                ],
+            },
+            {
+                'type': 'Nearness',
+                'targets': [
+                    {'type': 'Concept', 'name': 'chimp'},
+                    {'type': 'Concept', 'name': 'monkey'},
+                ],
+            },
+            {
+                'type': 'Connectivity',
+                'targets': [
+                    {
+                        'type': 'Nearness',
+                        'targets': [
+                            {'type': 'Concept', 'name': 'chimp'},
+                            {'type': 'Concept', 'name': 'human'},
+                        ],
+                    },
+                    {
+                        'type': 'Nearness',
+                        'targets': [
+                            {'type': 'Concept', 'name': 'chimp'},
+                            {'type': 'Concept', 'name': 'monkey'},
+                        ],
+                    },
+                ],
+            },
         ]
 
     @pytest.fixture()
@@ -439,6 +472,72 @@ class TestInMemoryDB:
         cursor, actual = database.get_matched_links('Evaluation', ['*', '*'], toplevel=True)
         assert cursor is None
         assert len(actual) == 2
+
+    # @pytest.mark.skip(
+    #     reason=(
+    #         "get_matched_links does not support nested lists in the target_handles parameter. "
+    #         "See: https://github.com/singnet/das-atom-db/issues/191"
+    #     )
+    # )
+    def test_get_matched_links_nested_lists(self, database: InMemoryDB):
+        chimp = ExpressionHasher.terminal_hash('Concept', 'chimp')
+        human = ExpressionHasher.terminal_hash('Concept', 'human')
+        monkey = ExpressionHasher.terminal_hash('Concept', 'monkey')
+        nearness_chimp_human = database.add_link(
+            {
+                'type': 'Nearness',
+                'targets': [
+                    {'type': 'Concept', 'name': 'chimp'},
+                    {'type': 'Concept', 'name': 'human'},
+                ],
+            }
+        )
+        nearness_chimp_human_handle = database.get_link_handle('Nearness', [chimp, human])
+        nearness_chimp_monkey = database.add_link(
+            {
+                'type': 'Nearness',
+                'targets': [
+                    {'type': 'Concept', 'name': 'chimp'},
+                    {'type': 'Concept', 'name': 'monkey'},
+                ],
+            }
+        )
+        nearness_chimp_monkey_handle = database.get_link_handle('Nearness', [chimp, monkey])
+        connectivity = database.add_link(
+            {
+                'type': 'Connectivity',
+                'targets': [
+                    {
+                        'type': 'Nearness',
+                        'targets': [
+                            {'type': 'Concept', 'name': 'chimp'},
+                            {'type': 'Concept', 'name': 'human'},
+                        ],
+                    },
+                    {
+                        'type': 'Nearness',
+                        'targets': [
+                            {'type': 'Concept', 'name': 'chimp'},
+                            {'type': 'Concept', 'name': 'monkey'},
+                        ],
+                    },
+                ],
+            }
+        )
+        connectivity_handle = database.get_link_handle(
+            'Connectivity', [nearness_chimp_human_handle, nearness_chimp_monkey_handle]
+        )
+        target_handles = [
+            connectivity_handle,
+            [nearness_chimp_human_handle, nearness_chimp_monkey_handle],
+        ]
+        links = database.get_matched_links('Connectivity', target_handles, toplevel=False)
+        # raise AssertionError(
+        #     f'{connectivity=}\n'
+        #     f'{nearness_chimp_human=}\n'
+        #     f'{nearness_chimp_monkey=}\n'
+        #     f'{links=}\n'
+        # )
 
     def test_get_all_nodes(self, database):
         ret = database.get_all_nodes('Concept')


### PR DESCRIPTION
Relates to #191 

Added a new test case, skipped for now, which must be enabled in the future once we get some refactorings done.

This is the error raised if the skip decorator is removed and a `make unit-tests` is executed:

```
>       _, links = database.get_matched_links('Connectivity', target_handles)

tests/unit/adapters/test_ram_only.py:483:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
hyperon_das_atomdb/adapters/ram_only.py:545: in get_matched_links
    link_handle = self.get_link_handle(link_type, target_handles)
hyperon_das_atomdb/adapters/ram_only.py:494: in get_link_handle
    link_handle = self.link_handle(link_type, target_handles)
hyperon_das_atomdb/database.py:123: in link_handle
    return ExpressionHasher.expression_hash(named_type_hash, target_handles)
hyperon_das_atomdb/utils/expression_hasher.py:86: in expression_hash
    return ExpressionHasher.composite_hash([named_type_hash, *elements])
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

hash_base = ['9bd9d0ebc081bd74f5bef4e136bb1aed', ['5b34c54bee150c04f9fa584b899dc030', 'af12f10f9ae2002a1607ba0b47ba8407'], ['5b34c54bee150c04f9fa584b899dc030', '1cdffc6b0b89ff41d68bec237481d1e1']]

    @staticmethod
    def composite_hash(hash_base: str | list[str]) -> str:
        """
        Compute the composite hash for the given base.

        This method generates a composite hash using the MD5 hashing algorithm. It can take
        either a single string or a list of strings as the base. If a list is provided, the
        elements are joined with a separator before hashing.

        Args:
            hash_base (str | list[str]): The base for the composite hash, either a single string
                                         or a list of strings.

        Returns:
            str: The MD5 hash of the composite base as a hexadecimal string.
        """
        if isinstance(hash_base, str):
            return hash_base
        elif isinstance(hash_base, list):
            if len(hash_base) == 1:
                return hash_base[0]
            else:
                return ExpressionHasher._compute_hash(
>                   ExpressionHasher.compound_separator.join(hash_base)
                )
E               TypeError: sequence item 1: expected str instance, list found

hyperon_das_atomdb/utils/expression_hasher.py:111: TypeError
```