### PR TITLE
[FIX] Fixing unspected value returning in the test

### DIFF
--- a/hyperon_das_atomdb/database.py
+++ b/hyperon_das_atomdb/database.py
@@ -898,6 +898,7 @@ class AtomDB(ABC):
         This method is intended to be implemented by subclasses to handle the commit operation,
         which may involve persisting changes to a storage backend or performing other necessary
         actions to finalize the current state of the database.
+        Updates of atoms aren't allowed on the same transaction.
 
         Args:
             **kwargs: Additional keyword arguments that may be used by the implementation of the

--- a/tests/integration/adapters/test_redis_mongo.py
+++ b/tests/integration/adapters/test_redis_mongo.py
@@ -39,6 +39,7 @@ class TestRedisMongo:
             db.add_link(link)
         for link in similarity_docs.values():
             db.add_link(link)
+        db.commit()
 
     def _connect_db(self):
         db = RedisMongoDB(

--- a/tests/integration/adapters/test_redis_mongo.py
+++ b/tests/integration/adapters/test_redis_mongo.py
@@ -39,7 +39,6 @@ class TestRedisMongo:
             db.add_link(link)
         for link in similarity_docs.values():
             db.add_link(link)
-        db.commit()
 
     def _connect_db(self):
         db = RedisMongoDB(
@@ -792,6 +791,7 @@ class TestRedisMongo:
     def test_create_field_index(self, _cleanup, _db: RedisMongoDB):
         db = _db
         self._add_atoms(db)
+        db.commit()
         db.add_link(
             {
                 "type": "Similarity",


### PR DESCRIPTION
AtomDB doesn't allow update atoms on the same transaction, to fix that we need to commit before update the atoms. 